### PR TITLE
feat: VirusTotal, PhishTank & URLhaus integrations

### DIFF
--- a/.github/workflows/update_intelligence.yml
+++ b/.github/workflows/update_intelligence.yml
@@ -272,6 +272,26 @@ jobs:
           fi
           cp data/shodan_intelligence.csv docs/data/ || true
 
+      - name: VirusTotal Enrichment
+        timeout-minutes: 30
+        continue-on-error: true
+        env:
+          VT_API_KEY: ${{ secrets.VT_API_Key }}
+        run: |
+          if [ -n "$VT_API_KEY" ]; then
+             python scripts/enrich_virustotal.py --input data/triage_candidates.csv \
+               --output data/virustotal_intelligence.csv --budget 500 --limit 500
+          fi
+          cp data/virustotal_intelligence.csv docs/data/ || true
+
+      - name: PhishTank & URLhaus Feed Matching
+        timeout-minutes: 30
+        continue-on-error: true
+        run: |
+          python scripts/enrich_phishtank.py --input data/dea_domains.csv \
+            --output data/phishtank_matches.csv
+          cp data/phishtank_matches.csv docs/data/ || true
+
       - name: Technical & Pivot Enrichment
         timeout-minutes: 20
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ data/.shodan_cache/
 data/.gleif_cache/
 data/.opensanctions_cache/
 data/.icij_cache/
+data/.vt_cache/
+data/.phishtank_cache/
 
 data/*.json
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -21,6 +21,11 @@ shodan:
   budget_default: 20
   rate_limit_rps: 1
 
+virustotal:
+  budget_default: 500
+  rate_limit_rpm: 4
+  cache_ttl_days: 7
+
 paths:
   classification_file: "data/ai_classifications.csv"
   briefing_file: "data/daily_briefing.json"

--- a/config/fingerprints/FP-0001-ovh-cpanel-dea.yaml
+++ b/config/fingerprints/FP-0001-ovh-cpanel-dea.yaml
@@ -46,6 +46,14 @@ confidence_modifiers:
     match_type: exact
     value: "True"
     delta: 15
+  - field: vt_malicious_count
+    match_type: range
+    value: "3-100"
+    delta: 20
+  - field: phishtank_match
+    match_type: exact
+    value: "True"
+    delta: 15
 
 flame_tp_ids:
   - "TP-0003"

--- a/config/fingerprints/FP-0002-alibaba-sideloading.yaml
+++ b/config/fingerprints/FP-0002-alibaba-sideloading.yaml
@@ -38,6 +38,14 @@ confidence_modifiers:
     match_type: exact
     value: "True"
     delta: 15
+  - field: vt_malicious_count
+    match_type: range
+    value: "3-100"
+    delta: 20
+  - field: phishtank_match
+    match_type: exact
+    value: "True"
+    delta: 15
 
 flame_tp_ids:
   - "TP-0012"

--- a/config/fingerprints/FP-0003-crypto-finance-cohosting.yaml
+++ b/config/fingerprints/FP-0003-crypto-finance-cohosting.yaml
@@ -42,6 +42,14 @@ confidence_modifiers:
     match_type: exact
     value: "True"
     delta: 15
+  - field: vt_malicious_count
+    match_type: range
+    value: "3-100"
+    delta: 20
+  - field: phishtank_match
+    match_type: exact
+    value: "True"
+    delta: 15
 
 flame_tp_ids:
   - "TP-0017"

--- a/config/fingerprints/FP-0004-gname-cloudflare-china.yaml
+++ b/config/fingerprints/FP-0004-gname-cloudflare-china.yaml
@@ -42,6 +42,14 @@ confidence_modifiers:
     match_type: exact
     value: "True"
     delta: 15
+  - field: vt_malicious_count
+    match_type: range
+    value: "3-100"
+    delta: 20
+  - field: phishtank_match
+    match_type: exact
+    value: "True"
+    delta: 15
 
 flame_tp_ids:
   - "TP-0017"

--- a/config/fingerprints/FP-0005-godaddy-bulk-registration.yaml
+++ b/config/fingerprints/FP-0005-godaddy-bulk-registration.yaml
@@ -38,6 +38,14 @@ confidence_modifiers:
     match_type: exact
     value: "True"
     delta: 15
+  - field: vt_malicious_count
+    match_type: range
+    value: "3-100"
+    delta: 20
+  - field: phishtank_match
+    match_type: exact
+    value: "True"
+    delta: 15
 
 flame_tp_ids:
   - "TP-0019"

--- a/config/fingerprints/FP-0006-shell-domain-mx-cluster.yaml
+++ b/config/fingerprints/FP-0006-shell-domain-mx-cluster.yaml
@@ -42,6 +42,14 @@ confidence_modifiers:
     match_type: exact
     value: "True"
     delta: 15
+  - field: vt_malicious_count
+    match_type: range
+    value: "3-100"
+    delta: 20
+  - field: phishtank_match
+    match_type: exact
+    value: "True"
+    delta: 15
 
 flame_tp_ids:
   - "TP-0003"

--- a/config/fingerprints/FP-0007-typosquat-evasion-infra.yaml
+++ b/config/fingerprints/FP-0007-typosquat-evasion-infra.yaml
@@ -39,6 +39,14 @@ confidence_modifiers:
     match_type: exact
     value: "True"
     delta: 15
+  - field: vt_malicious_count
+    match_type: range
+    value: "3-100"
+    delta: 20
+  - field: phishtank_match
+    match_type: exact
+    value: "True"
+    delta: 15
 
 flame_tp_ids:
   - "TP-0012"

--- a/scripts/enrich_phishtank.py
+++ b/scripts/enrich_phishtank.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+enrich_phishtank.py
+
+PhishTank & URLhaus Bulk Feed Matching.
+Downloads active phishing and malware feeds, extracts domains from URLs,
+and cross-references them against monitored domains.
+
+Output columns: domain, phishtank_match, phishtank_url, urlhaus_match, urlhaus_threat
+"""
+
+import argparse
+import csv
+import gzip
+import io
+import logging
+import os
+import sys
+import tempfile
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import requests
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+from shodan_utils import ShodanCache
+from shared.retry import retry
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+# --- Configuration ---
+
+PHISHTANK_URL = "http://data.phishtank.com/data/online-valid.csv.gz"
+URLHAUS_URL = "https://urlhaus.abuse.ch/downloads/csv/"
+DEFAULT_INPUT = "data/dea_domains.csv"
+DEFAULT_OUTPUT = "data/phishtank_matches.csv"
+CACHE_DB_PATH = "data/.phishtank_cache/cache.db"
+DATASET_TTL_DAYS = 1
+OUTPUT_COLUMNS = ["domain", "phishtank_match", "phishtank_url", "urlhaus_match", "urlhaus_threat"]
+
+
+# --- Core Functions ---
+
+def extract_domain_from_url(url: str) -> str:
+    """Extract and normalize the domain from a URL.
+
+    Uses urllib.parse.urlparse, strips port numbers, and lowercases.
+    Returns empty string on failure or empty input.
+    """
+    if not url or not url.strip():
+        return ""
+    try:
+        parsed = urlparse(url.strip())
+        netloc = parsed.netloc
+        if not netloc:
+            return ""
+        # Strip port if present
+        domain = netloc.split(":")[0]
+        return domain.lower()
+    except Exception:
+        return ""
+
+
+def parse_phishtank_csv(file_obj) -> Dict[str, str]:
+    """Parse PhishTank CSV and build a domain -> URL mapping.
+
+    Args:
+        file_obj: File-like object with PhishTank CSV data (with header).
+
+    Returns:
+        Dict mapping domain -> first phishing URL seen for that domain.
+    """
+    domain_map = {}
+    reader = csv.DictReader(file_obj)
+
+    for row in reader:
+        url = row.get("url", "").strip()
+        if not url:
+            continue
+        domain = extract_domain_from_url(url)
+        if domain and domain not in domain_map:
+            domain_map[domain] = url
+
+    logger.info("Parsed %d unique domains from PhishTank CSV", len(domain_map))
+    return domain_map
+
+
+def parse_urlhaus_csv(file_obj) -> Dict[str, Dict[str, str]]:
+    """Parse URLhaus CSV (with comment lines) and build a domain mapping.
+
+    URLhaus CSV has comment lines starting with #. These are skipped,
+    then the remaining lines are parsed as CSV with the first non-comment
+    line as the header.
+
+    Args:
+        file_obj: File-like object with URLhaus CSV data.
+
+    Returns:
+        Dict mapping domain -> {"threat": str, "url": str}.
+    """
+    domain_map = {}
+
+    # Read all lines, extracting column names from comment header
+    fieldnames = None
+    data_lines = []
+    for line in file_obj:
+        # Handle both bytes and str
+        if isinstance(line, bytes):
+            line = line.decode("utf-8", errors="replace")
+        if line.startswith("#"):
+            # Extract column names from "# Columns: ..." comment line
+            if line.lower().startswith("# columns:"):
+                cols_str = line.split(":", 1)[1].strip()
+                fieldnames = [c.strip() for c in cols_str.split(",")]
+        else:
+            data_lines.append(line)
+
+    if not data_lines:
+        return domain_map
+
+    # Parse remaining lines as CSV with extracted or default fieldnames
+    csv_text = "".join(data_lines)
+    if fieldnames is None:
+        # Fallback: assume first data line is a header
+        reader = csv.DictReader(io.StringIO(csv_text))
+    else:
+        reader = csv.DictReader(io.StringIO(csv_text), fieldnames=fieldnames)
+
+    for row in reader:
+        url = row.get("url", "").strip()
+        if not url:
+            continue
+        threat = row.get("threat", "").strip()
+        domain = extract_domain_from_url(url)
+        if domain and domain not in domain_map:
+            domain_map[domain] = {"threat": threat, "url": url}
+
+    logger.info("Parsed %d unique domains from URLhaus CSV", len(domain_map))
+    return domain_map
+
+
+def cross_reference_domains(
+    domains: List[str],
+    phishtank_map: Dict[str, str],
+    urlhaus_map: Dict[str, Dict[str, str]],
+) -> List[Dict[str, str]]:
+    """Cross-reference a list of domains against PhishTank and URLhaus maps.
+
+    Args:
+        domains: List of domain names to check.
+        phishtank_map: Domain -> URL mapping from PhishTank.
+        urlhaus_map: Domain -> {"threat", "url"} mapping from URLhaus.
+
+    Returns:
+        List of result dicts for matched domains only.
+    """
+    results = []
+
+    for domain in domains:
+        domain_lower = domain.lower().strip()
+        in_phishtank = domain_lower in phishtank_map
+        in_urlhaus = domain_lower in urlhaus_map
+
+        if in_phishtank or in_urlhaus:
+            result = {
+                "domain": domain,
+                "phishtank_match": "True" if in_phishtank else "",
+                "phishtank_url": phishtank_map.get(domain_lower, ""),
+                "urlhaus_match": "True" if in_urlhaus else "",
+                "urlhaus_threat": urlhaus_map.get(domain_lower, {}).get("threat", "") if in_urlhaus else "",
+            }
+            results.append(result)
+
+    return results
+
+
+@retry(max_attempts=3, backoff_base=2.0, exceptions=(requests.RequestException,))
+def _download(url: str, timeout: int = 120) -> requests.Response:
+    """Download a URL with retry and exponential backoff."""
+    return requests.get(url, timeout=timeout)
+
+
+def _load_cached_feeds(cache) -> Optional[Tuple[Dict, Dict]]:
+    """Load cached feed data if still fresh.
+
+    Args:
+        cache: ShodanCache instance.
+
+    Returns:
+        Tuple of (phishtank_map, urlhaus_map) if cached and fresh, else None.
+    """
+    meta = cache.get("_feed_meta", max_age_days=DATASET_TTL_DAYS)
+    if meta is None:
+        return None
+
+    phishtank_map = cache.get("_phishtank_domains", max_age_days=DATASET_TTL_DAYS)
+    urlhaus_map = cache.get("_urlhaus_domains", max_age_days=DATASET_TTL_DAYS)
+
+    if phishtank_map is not None and urlhaus_map is not None:
+        logger.info(
+            "Using cached feeds: %d PhishTank, %d URLhaus domains",
+            len(phishtank_map),
+            len(urlhaus_map),
+        )
+        return phishtank_map, urlhaus_map
+
+    return None
+
+
+def build_bad_domain_set(cache=None) -> Tuple[Dict, Dict]:
+    """Download and parse PhishTank and URLhaus feeds.
+
+    Uses caching to avoid re-downloading within DATASET_TTL_DAYS.
+    If one feed fails, continues with the other.
+
+    Args:
+        cache: Optional ShodanCache instance for caching.
+
+    Returns:
+        Tuple of (phishtank_map, urlhaus_map).
+    """
+    # Check cache first
+    if cache is not None:
+        cached = _load_cached_feeds(cache)
+        if cached is not None:
+            return cached
+
+    phishtank_map = {}
+    urlhaus_map = {}
+
+    # Download PhishTank (gzipped CSV)
+    try:
+        logger.info("Downloading PhishTank feed from %s", PHISHTANK_URL)
+        resp = _download(PHISHTANK_URL)
+        raw_csv = gzip.decompress(resp.content)
+        phishtank_map = parse_phishtank_csv(io.StringIO(raw_csv.decode("utf-8", errors="replace")))
+    except Exception as e:
+        logger.error("Failed to download/parse PhishTank feed: %s", e)
+
+    # Download URLhaus (plain CSV with comment lines)
+    try:
+        logger.info("Downloading URLhaus feed from %s", URLHAUS_URL)
+        resp = _download(URLHAUS_URL)
+        urlhaus_map = parse_urlhaus_csv(io.StringIO(resp.text))
+    except Exception as e:
+        logger.error("Failed to download/parse URLhaus feed: %s", e)
+
+    # Cache results
+    if cache is not None:
+        cache.set("_phishtank_domains", phishtank_map)
+        cache.set("_urlhaus_domains", urlhaus_map)
+        cache.set("_feed_meta", {
+            "phishtank_count": len(phishtank_map),
+            "urlhaus_count": len(urlhaus_map),
+        })
+
+    return phishtank_map, urlhaus_map
+
+
+def run(input_file: str, output_file: str) -> int:
+    """Run the PhishTank & URLhaus enrichment pipeline.
+
+    Args:
+        input_file: Input CSV path (must have a 'domain' column).
+        output_file: Output CSV path.
+
+    Returns:
+        Number of matched domains.
+    """
+    if not os.path.isfile(input_file):
+        logger.error("Input file not found: %s", input_file)
+        return 0
+
+    # Read input domains
+    with open(input_file, "r", encoding="utf-8-sig", errors="replace") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    domains = [row.get("domain", "").strip() for row in rows if row.get("domain", "").strip()]
+
+    if not domains:
+        logger.warning("No domains found in input file")
+        return 0
+
+    # Init cache
+    cache_dir = os.path.dirname(CACHE_DB_PATH) or "."
+    os.makedirs(cache_dir, exist_ok=True)
+    cache = ShodanCache(db_path=CACHE_DB_PATH)
+
+    try:
+        phishtank_map, urlhaus_map = build_bad_domain_set(cache=cache)
+        results = cross_reference_domains(domains, phishtank_map, urlhaus_map)
+
+        # Write output
+        os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
+        with open(output_file, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=OUTPUT_COLUMNS)
+            writer.writeheader()
+            writer.writerows(results)
+
+        logger.info(
+            "Found %d domain matches. Output: %s", len(results), output_file
+        )
+        return len(results)
+    finally:
+        cache.close()
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="PhishTank & URLhaus Bulk Feed Matching"
+    )
+    parser.add_argument("--input", default=DEFAULT_INPUT, help="Input CSV file")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help="Output CSV file")
+    args = parser.parse_args()
+
+    count = run(args.input, args.output)
+    logger.info("Done. %d domains matched.", count)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/enrich_phishtank.py
+++ b/scripts/enrich_phishtank.py
@@ -16,7 +16,7 @@ import io
 import logging
 import os
 import sys
-import tempfile
+
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 # --- Configuration ---
 
-PHISHTANK_URL = "http://data.phishtank.com/data/online-valid.csv.gz"
+PHISHTANK_URL = "https://data.phishtank.com/data/online-valid.csv.gz"
 URLHAUS_URL = "https://urlhaus.abuse.ch/downloads/csv/"
 DEFAULT_INPUT = "data/dea_domains.csv"
 DEFAULT_OUTPUT = "data/phishtank_matches.csv"
@@ -178,7 +178,9 @@ def cross_reference_domains(
 @retry(max_attempts=3, backoff_base=2.0, exceptions=(requests.RequestException,))
 def _download(url: str, timeout: int = 120) -> requests.Response:
     """Download a URL with retry and exponential backoff."""
-    return requests.get(url, timeout=timeout)
+    resp = requests.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp
 
 
 def _load_cached_feeds(cache) -> Optional[Tuple[Dict, Dict]]:

--- a/scripts/enrich_virustotal.py
+++ b/scripts/enrich_virustotal.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+enrich_virustotal.py
+
+VirusTotal API v3 domain enrichment.
+Queries VT for each domain in the triage candidates CSV and appends
+threat intelligence columns (malicious engine count, reputation score,
+last analysis date).
+"""
+
+import argparse
+import csv
+import logging
+import os
+import sys
+import time
+import threading
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import requests
+from dotenv import load_dotenv
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+from shodan_utils import ShodanCache, CreditBudget
+from shared.retry import retry
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+VT_API_BASE = "https://www.virustotal.com/api/v3/domains"
+DEFAULT_INPUT = "data/triage_candidates.csv"
+DEFAULT_OUTPUT = "data/virustotal_intelligence.csv"
+CACHE_DB_PATH = "data/.vt_cache/cache.db"
+CACHE_TTL_DAYS = 7
+DEFAULT_BUDGET = 500
+DEFAULT_RPM = 4  # requests per minute, VT free tier
+
+VT_COLUMNS = [
+    "vt_malicious_count",
+    "vt_total_engines",
+    "vt_reputation",
+    "vt_last_analysis_date",
+]
+
+EMPTY_RESULT: Dict[str, str] = {col: "" for col in VT_COLUMNS}
+
+
+# ---------------------------------------------------------------------------
+# Rate Limiter
+# ---------------------------------------------------------------------------
+
+class RateLimiter:
+    """Thread-safe rate limiter based on requests per minute."""
+
+    def __init__(self, requests_per_minute: float):
+        self._interval = 60.0 / requests_per_minute
+        self._lock = threading.Lock()
+        self._last_call: float = 0.0
+
+    def wait(self):
+        """Block until the minimum interval has elapsed since the last call."""
+        with self._lock:
+            now = time.time()
+            elapsed = now - self._last_call
+            to_wait = self._interval - elapsed
+            if to_wait > 0:
+                time.sleep(to_wait)
+            self._last_call = time.time()
+
+
+# ---------------------------------------------------------------------------
+# VT response parser
+# ---------------------------------------------------------------------------
+
+def parse_vt_response(data: dict) -> Dict[str, str]:
+    """Parse a VirusTotal API v3 JSON response into flat column values.
+
+    Args:
+        data: The full JSON dict returned by VT /domains/{domain}.
+
+    Returns:
+        Dict with keys matching VT_COLUMNS.
+    """
+    attrs = data.get("data", {}).get("attributes", {})
+    stats = attrs.get("last_analysis_stats", {})
+
+    malicious = stats.get("malicious", 0)
+    total = sum(stats.values()) if stats else 0
+    reputation = attrs.get("reputation", "")
+    analysis_epoch = attrs.get("last_analysis_date")
+
+    if analysis_epoch:
+        analysis_date = datetime.fromtimestamp(analysis_epoch, tz=timezone.utc).strftime("%Y-%m-%d")
+    else:
+        analysis_date = ""
+
+    return {
+        "vt_malicious_count": str(malicious),
+        "vt_total_engines": str(total),
+        "vt_reputation": str(reputation) if reputation != "" else "",
+        "vt_last_analysis_date": analysis_date,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Retry-wrapped API call
+# ---------------------------------------------------------------------------
+
+@retry(max_attempts=3, backoff_base=5.0, exceptions=(requests.RequestException,))
+def _vt_api_get(url: str, headers: dict) -> requests.Response:
+    """GET a VT API endpoint with automatic retry on transient errors."""
+    return requests.get(url, headers=headers, timeout=30)
+
+
+# ---------------------------------------------------------------------------
+# Query function
+# ---------------------------------------------------------------------------
+
+def query_virustotal(
+    domain: str,
+    api_key: str,
+    cache: Any,
+    budget: Any,
+    rate_limiter: RateLimiter,
+) -> Dict[str, str]:
+    """Query VirusTotal for a single domain.
+
+    Checks cache first, respects budget and rate limits.
+
+    Args:
+        domain: The domain name to look up.
+        api_key: VT API key.
+        cache: ShodanCache instance.
+        budget: CreditBudget instance.
+        rate_limiter: RateLimiter instance.
+
+    Returns:
+        Dict with VT_COLUMNS keys populated, or EMPTY_RESULT on failure.
+    """
+    cache_key = f"vt:{domain}"
+
+    # 1. Cache check
+    cached = cache.get(cache_key, max_age_days=CACHE_TTL_DAYS)
+    if cached is not None:
+        logger.debug("Cache HIT for %s", domain)
+        return cached
+
+    # 2. Budget check
+    if not budget.check_can_spend(1):
+        logger.warning("Budget exhausted — skipping %s", domain)
+        return dict(EMPTY_RESULT)
+
+    # 3. Rate limit
+    rate_limiter.wait()
+
+    # 4. Spend budget and call API
+    budget.spend(1)
+    url = f"{VT_API_BASE}/{domain}"
+    headers = {"x-apikey": api_key}
+
+    try:
+        resp = _vt_api_get(url, headers)
+    except requests.RequestException as exc:
+        logger.error("API request failed for %s: %s", domain, exc)
+        return dict(EMPTY_RESULT)
+
+    # 5. 200 — success
+    if resp.status_code == 200:
+        parsed = parse_vt_response(resp.json())
+        cache.set(cache_key, parsed)
+        return parsed
+
+    # 6. 404 — domain not found in VT
+    if resp.status_code == 404:
+        logger.info("VT 404 for %s — caching empty", domain)
+        empty = dict(EMPTY_RESULT)
+        cache.set(cache_key, empty)
+        return empty
+
+    # 7. 401 — bad key / unauthorised (do NOT cache)
+    if resp.status_code == 401:
+        logger.error("VT 401 Unauthorized for %s — check API key", domain)
+        return dict(EMPTY_RESULT)
+
+    # 8. Other status codes
+    logger.warning("VT returned %d for %s", resp.status_code, domain)
+    return dict(EMPTY_RESULT)
+
+
+# ---------------------------------------------------------------------------
+# Run pipeline
+# ---------------------------------------------------------------------------
+
+def run(
+    input_file: str,
+    output_file: str,
+    api_key: str,
+    budget_limit: int = DEFAULT_BUDGET,
+    rpm: float = DEFAULT_RPM,
+    limit: int = 0,
+) -> int:
+    """Run the VirusTotal enrichment pipeline.
+
+    Args:
+        input_file: Path to triage_candidates.csv (or similar).
+        output_file: Path for enriched output CSV.
+        api_key: VT API key.
+        budget_limit: Max API calls this run.
+        rpm: Requests per minute rate limit.
+        limit: Max domains to process (0 = all).
+
+    Returns:
+        Count of domains with malicious > 0.
+    """
+    if not os.path.isfile(input_file):
+        logger.error("Input file not found: %s", input_file)
+        return 0
+
+    # Read input
+    with open(input_file, "r", encoding="utf-8-sig", errors="replace") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames) if reader.fieldnames else []
+        rows = list(reader)
+
+    if not rows:
+        logger.warning("No rows in input file")
+        return 0
+
+    if limit > 0:
+        rows = rows[:limit]
+
+    # Init cache, budget, rate limiter
+    cache_dir = os.path.dirname(CACHE_DB_PATH) or "."
+    os.makedirs(cache_dir, exist_ok=True)
+    cache = ShodanCache(db_path=CACHE_DB_PATH)
+
+    budget = CreditBudget()
+    budget.set_budget(budget_limit)
+
+    rate_limiter = RateLimiter(requests_per_minute=rpm)
+
+    # Ensure VT columns in fieldnames
+    for col in VT_COLUMNS:
+        if col not in fieldnames:
+            fieldnames.append(col)
+
+    malicious_count = 0
+
+    try:
+        for i, row in enumerate(rows):
+            domain = row.get("domain", "").strip()
+            if not domain:
+                for col in VT_COLUMNS:
+                    row.setdefault(col, "")
+                continue
+
+            if (i + 1) % 10 == 0:
+                logger.info("[%d/%d] Processing VT queries...", i + 1, len(rows))
+
+            vt_data = query_virustotal(domain, api_key, cache, budget, rate_limiter)
+            for col in VT_COLUMNS:
+                row[col] = vt_data.get(col, "")
+
+            # Count domains with malicious > 0
+            try:
+                if int(vt_data.get("vt_malicious_count", "0") or "0") > 0:
+                    malicious_count += 1
+            except (ValueError, TypeError):
+                pass
+
+        # Write output
+        with open(output_file, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+        logger.info(
+            "VT enrichment complete. %d/%d domains flagged malicious. Output: %s",
+            malicious_count, len(rows), output_file,
+        )
+    finally:
+        cache.close()
+
+    return malicious_count
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    """CLI entry point."""
+    load_dotenv()
+    api_key = os.getenv("VT_API_KEY", "")
+
+    parser = argparse.ArgumentParser(description="VirusTotal domain enrichment")
+    parser.add_argument("--input", default=DEFAULT_INPUT, help="Input CSV file")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help="Output CSV file")
+    parser.add_argument("--budget", type=int, default=DEFAULT_BUDGET, help="Max API credits")
+    parser.add_argument("--limit", type=int, default=0, help="Max domains to process (0=all)")
+    parser.add_argument("--rpm", type=float, default=DEFAULT_RPM, help="Requests per minute")
+    args = parser.parse_args()
+
+    if not api_key:
+        logger.error("VT_API_KEY not set in environment or .env")
+        sys.exit(1)
+
+    count = run(args.input, args.output, api_key, args.budget, args.rpm, args.limit)
+    logger.info("Done. %d domains with malicious detections.", count)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/enrich_virustotal.py
+++ b/scripts/enrich_virustotal.py
@@ -117,8 +117,13 @@ def parse_vt_response(data: dict) -> Dict[str, str]:
 
 @retry(max_attempts=3, backoff_base=5.0, exceptions=(requests.RequestException,))
 def _vt_api_get(url: str, headers: dict) -> requests.Response:
-    """GET a VT API endpoint with automatic retry on transient errors."""
-    return requests.get(url, headers=headers, timeout=30)
+    """GET request to VT API with retry on transient errors."""
+    resp = requests.get(url, headers=headers, timeout=30)
+    if resp.status_code == 429:
+        raise requests.RequestException(
+            f"Rate limited (429), Retry-After: {resp.headers.get('Retry-After', 'unknown')}"
+        )
+    return resp
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +168,11 @@ def query_virustotal(
     rate_limiter.wait()
 
     # 4. Spend budget and call API
-    budget.spend(1)
+    try:
+        budget.spend(1)
+    except RuntimeError:
+        logger.warning("Budget exhausted during spend — skipping %s", domain)
+        return dict(EMPTY_RESULT)
     url = f"{VT_API_BASE}/{domain}"
     headers = {"x-apikey": api_key}
 

--- a/scripts/shodan_utils.py
+++ b/scripts/shodan_utils.py
@@ -42,6 +42,7 @@ class CreditBudget:
     def set_budget(self, limit: int):
         """Sets the ephemeral budget for this script execution."""
         self.budget_limit = limit
+        self.credits_used_session = 0
         log.info(f"CreditBudget initialized with limit: {limit}")
 
     def check_can_spend(self, cost: int = 1) -> bool:

--- a/tests/test_phishtank.py
+++ b/tests/test_phishtank.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for enrich_phishtank.py — PhishTank & URLhaus bulk feed matching."""
+
+import os
+import sys
+import csv
+import gzip
+import io
+import tempfile
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+from enrich_phishtank import (
+    extract_domain_from_url,
+    parse_phishtank_csv,
+    parse_urlhaus_csv,
+    build_bad_domain_set,
+    cross_reference_domains,
+)
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_PHISHTANK = """\
+phish_id,url,phish_detail_url,submission_time,verified,verification_time,online,target
+100001,http://evil-login.com/paypal/signin.php,http://www.phishtank.com/phish_detail.php?phish_id=100001,2026-01-01T00:00:00+00:00,yes,2026-01-01T01:00:00+00:00,yes,PayPal
+100002,https://secure-banking.fake.org:8443/login,http://www.phishtank.com/phish_detail.php?phish_id=100002,2026-01-02T00:00:00+00:00,yes,2026-01-02T01:00:00+00:00,yes,Bank of America
+100003,http://evil-login.com/chase/verify.html,http://www.phishtank.com/phish_detail.php?phish_id=100003,2026-01-03T00:00:00+00:00,yes,2026-01-03T01:00:00+00:00,yes,Chase
+"""
+
+SAMPLE_URLHAUS = """\
+# URLhaus Database Dump (CSV)
+# Columns: id,dateadded,url,url_status,last_online,threat,tags,urlhaus_link,reporter
+"1234","2026-01-15 10:00:00","http://malware-drop.net/payload.exe","online","2026-01-15","malware_download","elf,mozi","https://urlhaus.abuse.ch/url/1234/","reporter1"
+"1235","2026-01-16 11:00:00","http://evil-login.com/stealer.zip","online","2026-01-16","malware_download","exe","https://urlhaus.abuse.ch/url/1235/","reporter2"
+"1236","2026-01-17 12:00:00","http://clean-site.org/test","offline","2026-01-17","","","https://urlhaus.abuse.ch/url/1236/","reporter3"
+"""
+
+
+# ---------------------------------------------------------------------------
+# TestExtractDomainFromUrl
+# ---------------------------------------------------------------------------
+
+class TestExtractDomainFromUrl:
+    """Validate URL domain extraction."""
+
+    def test_extracts_simple_domain(self):
+        assert extract_domain_from_url("http://evil-login.com/path") == "evil-login.com"
+
+    def test_handles_ports_and_edge_cases(self):
+        assert extract_domain_from_url("https://secure.fake.org:8443/login") == "secure.fake.org"
+        assert extract_domain_from_url("") == ""
+        assert extract_domain_from_url("not-a-url") == ""
+
+
+# ---------------------------------------------------------------------------
+# TestParsePhishtankCsv
+# ---------------------------------------------------------------------------
+
+class TestParsePhishtankCsv:
+    """Validate PhishTank CSV parsing."""
+
+    def test_parses_phishtank_format(self):
+        domain_map = parse_phishtank_csv(io.StringIO(SAMPLE_PHISHTANK))
+        assert "evil-login.com" in domain_map
+        assert "secure-banking.fake.org" in domain_map
+
+
+# ---------------------------------------------------------------------------
+# TestParseUrlhausCsv
+# ---------------------------------------------------------------------------
+
+class TestParseUrlhausCsv:
+    """Validate URLhaus CSV parsing with comment lines."""
+
+    def test_parses_urlhaus_with_comments(self):
+        domain_map = parse_urlhaus_csv(io.StringIO(SAMPLE_URLHAUS))
+        assert "malware-drop.net" in domain_map
+        assert domain_map["malware-drop.net"]["threat"] == "malware_download"
+        assert "evil-login.com" in domain_map
+
+
+# ---------------------------------------------------------------------------
+# TestCrossReferenceDomains
+# ---------------------------------------------------------------------------
+
+class TestCrossReferenceDomains:
+    """Validate cross-reference matching logic."""
+
+    def test_finds_matching_domains(self):
+        phishtank_map = parse_phishtank_csv(io.StringIO(SAMPLE_PHISHTANK))
+        urlhaus_map = parse_urlhaus_csv(io.StringIO(SAMPLE_URLHAUS))
+        domains = ["evil-login.com", "safe-domain.org", "malware-drop.net"]
+        results = cross_reference_domains(domains, phishtank_map, urlhaus_map)
+        assert len(results) == 2
+
+    def test_no_matches_returns_empty(self):
+        results = cross_reference_domains(["safe.com", "clean.org"], {}, {})
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestDownloadCaching
+# ---------------------------------------------------------------------------
+
+class TestDownloadCaching:
+    """Validate feed caching respects TTL."""
+
+    def test_respects_ttl(self):
+        from enrich_phishtank import _load_cached_feeds
+
+        mock_cache = MagicMock()
+        mock_cache.get.side_effect = lambda key, max_age_days=1: {
+            "_feed_meta": {"phishtank_count": 10, "urlhaus_count": 5},
+            "_phishtank_domains": {"evil.com": "http://evil.com/phish"},
+            "_urlhaus_domains": {"bad.com": {"threat": "malware", "url": "http://bad.com/mal"}},
+        }.get(key)
+
+        result = _load_cached_feeds(mock_cache)
+        assert result is not None
+        phishtank_map, urlhaus_map = result
+        assert "evil.com" in phishtank_map
+        assert "bad.com" in urlhaus_map
+
+
+# ---------------------------------------------------------------------------
+# TestFingerprintModifiers
+# ---------------------------------------------------------------------------
+
+class TestFingerprintModifiers:
+    """Validate that phishtank_match works as a confidence modifier."""
+
+    def test_phishtank_match_applies_delta(self):
+        from match_fingerprints import calculate_confidence
+
+        fp = {
+            "id": "FP-TEST",
+            "name": "Test",
+            "description": "test",
+            "version": 1,
+            "indicators": [],
+            "confidence_base": 60,
+            "confidence_modifiers": [
+                {
+                    "field": "phishtank_match",
+                    "match_type": "exact",
+                    "value": "True",
+                    "delta": 15,
+                },
+            ],
+            "flame_tp_ids": [],
+            "ttl_days": 30,
+        }
+        row = {"domain": "evil.com", "phishtank_match": "True"}
+        assert calculate_confidence(fp, row) == 75

--- a/tests/test_virustotal.py
+++ b/tests/test_virustotal.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+tests/test_virustotal.py
+
+Unit tests for the VirusTotal enrichment module.
+"""
+
+import os
+import sys
+import time
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+from enrich_virustotal import (
+    parse_vt_response,
+    query_virustotal,
+    RateLimiter,
+    VT_COLUMNS,
+    EMPTY_RESULT,
+)
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_VT_RESPONSE = {
+    "data": {
+        "id": "evil-example.com",
+        "type": "domain",
+        "attributes": {
+            "last_analysis_stats": {
+                "malicious": 5,
+                "suspicious": 2,
+                "undetected": 70,
+                "harmless": 10,
+                "timeout": 0,
+            },
+            "reputation": -42,
+            "last_analysis_date": 1740000000,
+        },
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# TestParseVtResponse
+# ---------------------------------------------------------------------------
+
+class TestParseVtResponse:
+
+    def test_parses_malicious_domain(self):
+        """Full VT response is parsed into expected columns."""
+        result = parse_vt_response(SAMPLE_VT_RESPONSE)
+        assert result["vt_malicious_count"] == "5"
+        assert result["vt_total_engines"] == "87"
+        assert result["vt_reputation"] == "-42"
+        assert result["vt_last_analysis_date"] != ""
+
+    def test_handles_missing_fields(self):
+        """Partial response with missing attributes returns safe defaults."""
+        partial = {"data": {"attributes": {}}}
+        result = parse_vt_response(partial)
+        assert result["vt_malicious_count"] == "0"
+        assert result["vt_total_engines"] == "0"
+        assert result["vt_reputation"] == ""
+        assert result["vt_last_analysis_date"] == ""
+
+
+# ---------------------------------------------------------------------------
+# TestRateLimiter
+# ---------------------------------------------------------------------------
+
+class TestRateLimiter:
+
+    def test_enforces_interval(self):
+        """Two consecutive wait() calls on a 60 RPM limiter should take ~1s."""
+        limiter = RateLimiter(requests_per_minute=60)
+        start = time.time()
+        limiter.wait()
+        limiter.wait()
+        elapsed = time.time() - start
+        assert elapsed >= 0.9, f"Expected >= 0.9s, got {elapsed:.2f}s"
+
+
+# ---------------------------------------------------------------------------
+# TestBudgetEnforcement
+# ---------------------------------------------------------------------------
+
+class TestBudgetEnforcement:
+
+    def test_budget_exhausted_returns_empty(self):
+        """When budget is exhausted, query returns EMPTY_RESULT."""
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        mock_budget = MagicMock()
+        mock_budget.check_can_spend.return_value = False
+
+        mock_limiter = MagicMock()
+
+        result = query_virustotal(
+            "example.com", "fake-key", mock_cache, mock_budget, mock_limiter
+        )
+        assert result == EMPTY_RESULT
+
+    @patch("enrich_virustotal._vt_api_get")
+    def test_budget_tracks_spend(self, mock_get):
+        """Successful API call should call budget.spend(1)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_VT_RESPONSE
+        mock_get.return_value = mock_resp
+
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        mock_budget = MagicMock()
+        mock_budget.check_can_spend.return_value = True
+
+        mock_limiter = MagicMock()
+
+        query_virustotal(
+            "example.com", "fake-key", mock_cache, mock_budget, mock_limiter
+        )
+        mock_budget.spend.assert_called_once_with(1)
+
+
+# ---------------------------------------------------------------------------
+# TestCacheBehavior
+# ---------------------------------------------------------------------------
+
+class TestCacheBehavior:
+
+    @patch("enrich_virustotal.requests.get")
+    def test_cache_hit_skips_api(self, mock_get):
+        """When cache returns data, requests.get should NOT be called."""
+        cached_data = {
+            "vt_malicious_count": "3",
+            "vt_total_engines": "80",
+            "vt_reputation": "-10",
+            "vt_last_analysis_date": "2025-01-01",
+        }
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = cached_data
+
+        mock_budget = MagicMock()
+        mock_limiter = MagicMock()
+
+        result = query_virustotal(
+            "example.com", "fake-key", mock_cache, mock_budget, mock_limiter
+        )
+        assert result == cached_data
+        mock_get.assert_not_called()
+
+    @patch("enrich_virustotal._vt_api_get")
+    def test_cache_miss_stores_result(self, mock_get):
+        """Cache miss + successful API call should store result in cache."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_VT_RESPONSE
+        mock_get.return_value = mock_resp
+
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        mock_budget = MagicMock()
+        mock_budget.check_can_spend.return_value = True
+
+        mock_limiter = MagicMock()
+
+        query_virustotal(
+            "example.com", "fake-key", mock_cache, mock_budget, mock_limiter
+        )
+        mock_cache.set.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestErrorHandling
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+
+    @patch("enrich_virustotal._vt_api_get")
+    def test_404_caches_empty(self, mock_get):
+        """404 response should cache EMPTY_RESULT."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        mock_budget = MagicMock()
+        mock_budget.check_can_spend.return_value = True
+
+        mock_limiter = MagicMock()
+
+        result = query_virustotal(
+            "example.com", "fake-key", mock_cache, mock_budget, mock_limiter
+        )
+        assert result == EMPTY_RESULT
+        mock_cache.set.assert_called_once()
+
+    @patch("enrich_virustotal._vt_api_get")
+    def test_401_returns_empty_no_cache(self, mock_get):
+        """401 response should return EMPTY_RESULT without caching."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_get.return_value = mock_resp
+
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        mock_budget = MagicMock()
+        mock_budget.check_can_spend.return_value = True
+
+        mock_limiter = MagicMock()
+
+        result = query_virustotal(
+            "example.com", "fake-key", mock_cache, mock_budget, mock_limiter
+        )
+        assert result == EMPTY_RESULT
+        mock_cache.set.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestFingerprintModifiers
+# ---------------------------------------------------------------------------
+
+class TestFingerprintModifiers:
+
+    def test_vt_malicious_count_applies_delta(self):
+        """vt_malicious_count in range 3-100 should apply +20 delta."""
+        from match_fingerprints import calculate_confidence, validate_fingerprint
+
+        fp = {
+            "id": "FP-TEST",
+            "name": "Test",
+            "description": "",
+            "version": 1,
+            "indicators": [
+                {"field": "asn", "match_type": "exact", "value": "16276", "required": True},
+            ],
+            "confidence_base": 60,
+            "confidence_modifiers": [
+                {"field": "vt_malicious_count", "match_type": "range", "value": "3-100", "delta": 20},
+            ],
+            "flame_tp_ids": [],
+            "ttl_days": 30,
+        }
+        fp = validate_fingerprint(fp, source="test")
+        row = {"asn": "16276", "vt_malicious_count": "5"}
+        assert calculate_confidence(fp, row) == 80


### PR DESCRIPTION
## Summary

- **VirusTotal API v3 enrichment** (`scripts/enrich_virustotal.py`) — queries VT for each triaged domain with budget (500/run), rate limiting (4/min), ShodanCache (7-day TTL), and 429 retry handling. Output: `vt_malicious_count`, `vt_total_engines`, `vt_reputation`, `vt_last_analysis_date`.
- **PhishTank & URLhaus bulk feed matching** (`scripts/enrich_phishtank.py`) — downloads PhishTank (gzipped CSV) and URLhaus feeds, extracts domains from URLs, cross-references against `dea_domains.csv`. Output: `phishtank_match`, `phishtank_url`, `urlhaus_match`, `urlhaus_threat`. 24-hour download cache.
- **Fingerprint modifiers** added to all 7 YAMLs: `vt_malicious_count` range 3-100 → +20 delta, `phishtank_match` exact "True" → +15 delta.
- **Pipeline integration** after Shodan, before Technical/Pivot. VT gated behind `VT_API_Key` secret; PhishTank requires no API key.
- **Defensive fix**: `CreditBudget.set_budget()` now resets session counter to prevent singleton state leak.

## Test plan
- [x] 10 VT tests pass (parsing, rate limiting, budget, cache, errors, modifier)
- [x] 8 PhishTank tests pass (URL extraction, CSV parsing, cross-referencing, caching, modifier)
- [x] All 204 project tests pass
- [x] All 7 fingerprints load with 6-8 modifiers each
- [x] Workflow YAML validates

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)