### PR TITLE
Fix campaign hunt IPs never entering enrichment pipeline

### DIFF
--- a/.github/workflows/update_intelligence.yml
+++ b/.github/workflows/update_intelligence.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Proactive Campaign Hunt
         env:
           SHODAN_API_KEY: ${{ secrets.SHODAN_API_KEY }}
+          ALIENVAULT_OTX_API_KEY: ${{ secrets.ALIENVAULT_OTX_API_KEY }}
         run: python scripts/hunt_campaign.py
 
       - name: Run CT Discovery
@@ -45,6 +46,7 @@ jobs:
             data/potential_typosquats.csv
             data/discovered_certs.csv
             data/campaign_hunt_history.csv
+            data/campaign_pivot_findings.csv
           retention-days: 7
 
   setup:

--- a/scripts/merge_lists_v3b.py
+++ b/scripts/merge_lists_v3b.py
@@ -275,6 +275,25 @@ def collect_discovery_domains(targets: Set[str]) -> Dict[str, Set[str]]:
         except Exception as e:
             log(f"  [!] Failed to read {manual_file}: {e}")
 
+    # 5. Campaign pivot discoveries (Shodan hunt -> OTX passive DNS)
+    pivot_file = "data/campaign_pivot_findings.csv"
+    if os.path.exists(pivot_file):
+        try:
+            pivots = set()
+            with open(pivot_file, "r", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    d = normalize_domain(row.get("discovered_domain", ""))
+                    if d in targets:
+                        continue
+                    if is_valid_domain(d):
+                        pivots.add(d)
+            if pivots:
+                log(f"  [+] {'campaign_pivot':28s} {len(pivots):7d} domains  (local, targets excluded)")
+                discovery["campaign_pivot"] = pivots
+        except Exception as e:
+            log(f"  [!] Failed to read {pivot_file}: {e}")
+
     return discovery
 
 


### PR DESCRIPTION
The OTX passive DNS pivot in hunt_campaign.py was silently failing
because ALIENVAULT_OTX_API_KEY was not passed to the discovery job step.
Additionally, campaign_pivot_findings.csv was never uploaded as an
artifact or consumed by merge_lists_v3b.py.

Three fixes:
- Pass ALIENVAULT_OTX_API_KEY to the Proactive Campaign Hunt step
- Add campaign_pivot_findings.csv to discovery artifact upload
- Add campaign_pivot source to collect_discovery_domains() in merge_lists

https://claude.ai/code/session_01LFRfpmoSdQ4xJQdYU51iv7