### PR TITLE
feat: close Mullvad exit IP gap with hybrid collection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 dnspython>=2.6.1
 tqdm>=4.0.0
 requests>=2.20.0
+PySocks>=1.7.0
 aiohttp>=3.8.0
 litellm<=1.83.7
 python-dotenv

--- a/scripts/mullvad_exit_probe.py
+++ b/scripts/mullvad_exit_probe.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+mullvad_exit_probe.py
+
+Discovers Mullvad VPN exit IPs by probing each relay via its SOCKS5 proxy.
+Requires an active Mullvad WireGuard connection.
+
+Usage:
+  python mullvad_exit_probe.py [--output data/vpn_seeds/mullvad_exit_ips.csv] [--limit N]
+"""
+
+import argparse
+import csv
+import logging
+import os
+import sys
+import time
+from datetime import date
+from typing import Dict, List, Optional
+
+import requests
+
+sys.path.insert(0, os.path.dirname(__file__))
+from shared.retry import retry
+
+logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
+logger = logging.getLogger(__name__)
+
+TODAY = date.today().isoformat()
+API_URL = "https://api.mullvad.net/www/relays/all/"
+ECHO_URL = "https://am.i.mullvad.net/json"
+DEFAULT_OUTPUT = os.path.join(os.path.dirname(__file__), "..", "data", "vpn_seeds", "mullvad_exit_ips.csv")
+SEED_FIELDS = ["relay_hostname", "ingress_ip", "exit_ip", "probe_date"]
+
+
+def fetch_relays() -> List[Dict]:
+    """Fetch active Mullvad relays with SOCKS5 info."""
+    resp = requests.get(API_URL, timeout=30)
+    resp.raise_for_status()
+    relays = []
+    for s in resp.json():
+        if not s.get("active") or not s.get("ipv4_addr_in"):
+            continue
+        if not s.get("socks_name"):
+            continue
+        relays.append({
+            "hostname": s["hostname"],
+            "ipv4_addr_in": s["ipv4_addr_in"],
+            "socks_name": s["socks_name"],
+            "socks_port": s.get("socks_port", 1080),
+            "country_code": s.get("country_code", ""),
+            "city_name": s.get("city_name", ""),
+        })
+    logger.info(f"Fetched {len(relays)} active relays with SOCKS5")
+    return relays
+
+
+@retry(max_attempts=2, backoff_base=2.0, exceptions=(requests.RequestException,))
+def probe_relay(relay: Dict) -> Optional[str]:
+    """Probe a single relay's SOCKS5 proxy to discover its exit IP.
+    Returns the exit IP string, or None on failure.
+    """
+    proxy_url = f"socks5h://{relay['socks_name']}:{relay['socks_port']}"
+    proxies = {"http": proxy_url, "https": proxy_url}
+    try:
+        resp = requests.get(ECHO_URL, proxies=proxies, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        exit_ip = data.get("ip", "")
+        if exit_ip:
+            return exit_ip
+    except Exception as e:
+        logger.debug(f"Probe failed for {relay['hostname']}: {e}")
+        return None
+    return None
+
+
+def write_results(results: List[Dict], path: str) -> None:
+    """Write probe results to CSV."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=SEED_FIELDS)
+        writer.writeheader()
+        writer.writerows(results)
+    logger.info(f"Wrote {len(results)} exit IPs to {path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mullvad Exit IP Probe via SOCKS5")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help="Output CSV path")
+    parser.add_argument("--limit", type=int, default=0, help="Limit number of relays to probe (0 = all)")
+    parser.add_argument("--delay", type=float, default=1.0, help="Delay between probes in seconds")
+    args = parser.parse_args()
+
+    relays = fetch_relays()
+    if args.limit:
+        relays = relays[:args.limit]
+
+    logger.info(f"Probing {len(relays)} relays (delay={args.delay}s)...")
+    results = []
+    for i, relay in enumerate(relays, 1):
+        logger.info(f"[{i}/{len(relays)}] {relay['hostname']} ({relay['ipv4_addr_in']})...")
+        exit_ip = probe_relay(relay)
+        if exit_ip:
+            results.append({
+                "relay_hostname": relay["hostname"],
+                "ingress_ip": relay["ipv4_addr_in"],
+                "exit_ip": exit_ip,
+                "probe_date": TODAY,
+            })
+            logger.info(f"  -> exit: {exit_ip}")
+        else:
+            logger.warning(f"  -> FAILED")
+
+        if i < len(relays):
+            time.sleep(args.delay)
+
+    write_results(results, args.output)
+    logger.info(f"Done. {len(results)}/{len(relays)} relays probed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mullvad_exit_probe.py
+++ b/scripts/mullvad_exit_probe.py
@@ -55,7 +55,6 @@ def fetch_relays() -> List[Dict]:
     return relays
 
 
-@retry(max_attempts=2, backoff_base=2.0, exceptions=(requests.RequestException,))
 def probe_relay(relay: Dict) -> Optional[str]:
     """Probe a single relay's SOCKS5 proxy to discover its exit IP.
     Returns the exit IP string, or None on failure.
@@ -71,7 +70,6 @@ def probe_relay(relay: Dict) -> Optional[str]:
             return exit_ip
     except Exception as e:
         logger.debug(f"Probe failed for {relay['hostname']}: {e}")
-        return None
     return None
 
 

--- a/scripts/shared/rdap_client.py
+++ b/scripts/shared/rdap_client.py
@@ -79,6 +79,43 @@ class RDAPClient:
                 continue
         return ""
 
+    def check_block_cidr(self, ip: str) -> tuple:
+        """Returns (registration_name, allocated_cidr) for the IP block.
+        Returns ("", "") on failure.
+        """
+        import ipaddress as _ipaddress
+
+        for base_url in RDAP_URLS:
+            try:
+                resp = self.session.get(f"{base_url}{ip}", timeout=10, allow_redirects=True)
+                if resp.status_code != 200:
+                    continue
+                data = resp.json()
+                name = data.get("name", "")
+
+                # Prefer cidr0_cidrs (standard RDAP field)
+                cidr = ""
+                cidr0 = data.get("cidr0_cidrs", [])
+                if cidr0:
+                    entry = cidr0[0]
+                    prefix = entry.get("v4prefix", "")
+                    length = entry.get("length", 0)
+                    if prefix and length:
+                        cidr = f"{prefix}/{length}"
+                elif data.get("startAddress") and data.get("endAddress"):
+                    # Fallback: compute from start/end addresses
+                    start = _ipaddress.ip_address(data["startAddress"])
+                    end = _ipaddress.ip_address(data["endAddress"])
+                    nets = list(_ipaddress.summarize_address_range(start, end))
+                    if nets:
+                        cidr = str(nets[0])
+
+                return (name, cidr)
+            except Exception as e:
+                logger.debug(f"RDAP CIDR lookup failed for {ip} at {base_url}: {e}")
+                continue
+        return ("", "")
+
     def validate_astrill_blocks(self, ips: list) -> set:
         """Check which IPs are in RDAP blocks registered to Astrill.
         Groups by /24, checks one sample per /24, caches results.

--- a/scripts/vpn_ip_intel.py
+++ b/scripts/vpn_ip_intel.py
@@ -154,16 +154,12 @@ class MullvadProvider(BaseProvider):
 
     def load_exit_seeds(self) -> List[Dict]:
         """Load exit IPs from SOCKS5 probe seed CSV if present."""
-        import vpn_ip_intel as _self_module
-        seed_path = os.path.join(
-            os.path.dirname(_self_module.__file__), "..", "data", "vpn_seeds", "mullvad_exit_ips.csv"
-        )
-        if not os.path.exists(seed_path):
+        if not os.path.exists(self.SEED_PATH):
             logger.info("  No Mullvad exit seed file found; skipping egress IPs")
             return []
 
         nodes = []
-        with open(seed_path, encoding="utf-8") as f:
+        with open(self.SEED_PATH, encoding="utf-8") as f:
             for row in csv.DictReader(f):
                 exit_ip = row.get("exit_ip", "").strip()
                 if not exit_ip:
@@ -934,18 +930,29 @@ def compute_rdap_egress_rows(nodes: List[Dict], rdap: "RDAPClient" = None) -> Li
             except ValueError:
                 pass
 
-    checked = {}
+    # Cache RDAP results by /24 to avoid redundant lookups.
+    # Once we know a /24 falls within a larger RDAP block, we cache
+    # all /24s in that block to skip future queries.
+    net24_to_cidr = {}  # net24_str -> (name, cidr)
     synthetic = []
 
     for (provider, asn, net24_str), members in groups.items():
-        pa_key = (provider, asn)
-        if pa_key not in checked:
+        if net24_str not in net24_to_cidr:
             sample_ip = members[0]["ip"]
             name, cidr = rdap.check_block_cidr(sample_ip)
-            checked[pa_key] = (name, cidr)
+            # Cache this /24 and pre-cache all /24s within the returned block
+            net24_to_cidr[net24_str] = (name, cidr)
+            if cidr:
+                try:
+                    block = ipaddress.ip_network(cidr, strict=False)
+                    if 16 <= block.prefixlen <= 24:
+                        for sub in ([block] if block.prefixlen == 24 else block.subnets(new_prefix=24)):
+                            net24_to_cidr.setdefault(str(sub), (name, cidr))
+                except ValueError:
+                    pass
             _time.sleep(0.3)
 
-        name, cidr = checked[pa_key]
+        name, cidr = net24_to_cidr[net24_str]
         if not cidr:
             continue
 
@@ -986,7 +993,7 @@ def compute_rdap_egress_rows(nodes: List[Dict], rdap: "RDAPClient" = None) -> Li
                 row[sf] = tmpl.get(sf, "")
             synthetic.append(row)
 
-    logger.info(f"RDAP egress expansion: {len(synthetic)} inferred /24 blocks from {len(checked)} lookups")
+    logger.info(f"RDAP egress expansion: {len(synthetic)} inferred /24 blocks from {len(net24_to_cidr)} cached entries")
     return synthetic
 
 

--- a/scripts/vpn_ip_intel.py
+++ b/scripts/vpn_ip_intel.py
@@ -41,7 +41,7 @@ FIELDS = [
     "indicator_id",
 ]
 
-IP_ROLES = {"ingress", "egress", "prefix-inferred", "unknown"}
+IP_ROLES = {"ingress", "egress", "prefix-inferred", "egress-inferred", "unknown"}
 
 SHARED_HOSTING_ASNS = {
     "AS16509",   # AWS
@@ -889,11 +889,11 @@ def run(output: str, output_dir: str, workers: int, providers: List[str]):
     for n in all_nodes:
         normalize_node(n)
 
-    # Deduplicate on (ip, provider)
+    # Deduplicate on (ip, provider, ip_role)
     seen = set()
     deduped = []
     for n in all_nodes:
-        key = (n["ip"], n["provider"])
+        key = (n["ip"], n["provider"], n.get("ip_role", "unknown"))
         if key not in seen:
             seen.add(key)
             deduped.append(n)

--- a/scripts/vpn_ip_intel.py
+++ b/scripts/vpn_ip_intel.py
@@ -954,11 +954,12 @@ def compute_rdap_egress_rows(nodes: List[Dict], rdap: "RDAPClient" = None) -> Li
         except ValueError:
             continue
 
-        if allocated.prefixlen < 16:
+        if allocated.prefixlen < 16 or allocated.prefixlen > 24:
             continue
 
         tmpl = members[0]
-        for subnet in allocated.subnets(new_prefix=24):
+        subnets = [allocated] if allocated.prefixlen == 24 else list(allocated.subnets(new_prefix=24))
+        for subnet in subnets:
             subnet_str = str(subnet)
             if subnet_str in covered_24s:
                 continue

--- a/scripts/vpn_ip_intel.py
+++ b/scripts/vpn_ip_intel.py
@@ -897,6 +897,98 @@ def compute_prefix_inferred_rows(nodes: List[Dict], threshold: int = 4) -> List[
     return synthetic
 
 
+def compute_rdap_egress_rows(nodes: List[Dict], rdap: "RDAPClient" = None) -> List[Dict]:
+    """Infer egress /24 prefixes by querying RDAP for allocated blocks.
+
+    For each (provider, ASN, /24) group with ingress IPs, checks RDAP for the
+    allocated block. Any /24 within that block that does NOT already have confirmed
+    IPs gets an egress-inferred row.
+
+    Only processes nodes with ip_role='ingress'. Skips SHARED_HOSTING_ASNS.
+    """
+    import time as _time
+
+    if rdap is None:
+        rdap = RDAPClient()
+
+    ingress_nodes = [n for n in nodes if n.get("ip_role") == "ingress"]
+    if not ingress_nodes:
+        return []
+
+    groups = defaultdict(list)
+    for n in ingress_nodes:
+        asn = n.get("asn", "")
+        if not asn or asn in SHARED_HOSTING_ASNS:
+            continue
+        try:
+            net24 = ipaddress.ip_network(f"{n['ip']}/24", strict=False)
+        except ValueError:
+            continue
+        groups[(n["provider"], asn, str(net24))].append(n)
+
+    covered_24s = set()
+    for n in nodes:
+        if n.get("ip"):
+            try:
+                covered_24s.add(str(ipaddress.ip_network(f"{n['ip']}/24", strict=False)))
+            except ValueError:
+                pass
+
+    checked = {}
+    synthetic = []
+
+    for (provider, asn, net24_str), members in groups.items():
+        pa_key = (provider, asn)
+        if pa_key not in checked:
+            sample_ip = members[0]["ip"]
+            name, cidr = rdap.check_block_cidr(sample_ip)
+            checked[pa_key] = (name, cidr)
+            _time.sleep(0.3)
+
+        name, cidr = checked[pa_key]
+        if not cidr:
+            continue
+
+        try:
+            allocated = ipaddress.ip_network(cidr, strict=False)
+        except ValueError:
+            continue
+
+        if allocated.prefixlen < 16:
+            continue
+
+        tmpl = members[0]
+        for subnet in allocated.subnets(new_prefix=24):
+            subnet_str = str(subnet)
+            if subnet_str in covered_24s:
+                continue
+            covered_24s.add(subnet_str)
+
+            row = {
+                "ip": "",
+                "provider": provider,
+                "confidence": "medium",
+                "country": tmpl.get("country", ""),
+                "city": "",
+                "server_type": tmpl.get("server_type", ""),
+                "asn": asn,
+                "asn_name": tmpl.get("asn_name", ""),
+                "source": "rdap_prefix_expansion",
+                "source_date": TODAY,
+                "hostname": "",
+                "collection_method": tmpl.get("collection_method", ""),
+                "threat_relevance": tmpl.get("threat_relevance", ""),
+                "ip_role": "egress-inferred",
+                "prefix": subnet_str,
+            }
+            for sf in SCORE_FIELDS:
+                row[sf] = tmpl.get(sf, "")
+            synthetic.append(row)
+
+    logger.info(f"RDAP egress expansion: {len(synthetic)} inferred /24 blocks from {len(checked)} lookups")
+    return synthetic
+
+
 def write_csv(nodes: List[Dict], path: str) -> None:
     """Write nodes to CSV."""
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
@@ -951,7 +1043,11 @@ def run(output: str, output_dir: str, workers: int, providers: List[str]):
 
     # Prefix inference: emit synthetic /24 rows
     prefix_rows = compute_prefix_inferred_rows(all_nodes)
-    all_nodes_with_prefix = all_nodes + prefix_rows
+
+    # RDAP egress expansion: infer adjacent /24s for ingress-only providers
+    egress_rows = compute_rdap_egress_rows(all_nodes)
+
+    all_nodes_with_prefix = all_nodes + prefix_rows + egress_rows
 
     # Write primary CSV (all rows including prefix-inferred)
     write_csv(all_nodes_with_prefix, output)

--- a/scripts/vpn_ip_intel.py
+++ b/scripts/vpn_ip_intel.py
@@ -140,7 +140,51 @@ class MullvadProvider(BaseProvider):
                 "prefix": "",
             })
 
-        logger.info(f"  {self.display_name}: {len(nodes)} active servers")
+        logger.info(f"  {self.display_name}: {len(nodes)} active ingress servers")
+
+        # Merge exit IPs from probe seed file
+        egress_nodes = self.load_exit_seeds()
+        nodes.extend(egress_nodes)
+
+        return nodes
+
+    SEED_PATH = os.path.join(
+        os.path.dirname(__file__), "..", "data", "vpn_seeds", "mullvad_exit_ips.csv"
+    )
+
+    def load_exit_seeds(self) -> List[Dict]:
+        """Load exit IPs from SOCKS5 probe seed CSV if present."""
+        import vpn_ip_intel as _self_module
+        seed_path = os.path.join(
+            os.path.dirname(_self_module.__file__), "..", "data", "vpn_seeds", "mullvad_exit_ips.csv"
+        )
+        if not os.path.exists(seed_path):
+            logger.info("  No Mullvad exit seed file found; skipping egress IPs")
+            return []
+
+        nodes = []
+        with open(seed_path, encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                exit_ip = row.get("exit_ip", "").strip()
+                if not exit_ip:
+                    continue
+                nodes.append({
+                    "ip": exit_ip,
+                    "provider": self.name,
+                    "confidence": "confirmed",
+                    "country": "",
+                    "city": "",
+                    "server_type": "exit",
+                    "asn": "",
+                    "asn_name": "",
+                    "source": "socks5_probe",
+                    "source_date": row.get("probe_date", TODAY),
+                    "hostname": row.get("relay_hostname", ""),
+                    "ip_role": "egress",
+                    "prefix": "",
+                })
+
+        logger.info(f"  {self.display_name} exit seeds: {len(nodes)} egress IPs")
         return nodes
 
 

--- a/tests/test_mullvad_exit_probe.py
+++ b/tests/test_mullvad_exit_probe.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tests for Mullvad SOCKS5 exit IP probe."""
+
+import pytest
+import sys
+import os
+import csv
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+from unittest.mock import patch, MagicMock
+from mullvad_exit_probe import probe_relay, fetch_relays, write_results
+
+
+class TestFetchRelays:
+    SAMPLE_RELAYS = [
+        {
+            "hostname": "us-mkc-wg-001",
+            "active": True,
+            "ipv4_addr_in": "155.2.191.3",
+            "socks_name": "us-mkc-wg-socks5-001.relays.mullvad.net",
+            "socks_port": 1080,
+            "type": "wireguard",
+            "country_code": "us",
+            "city_name": "Kansas City, MO",
+        },
+        {
+            "hostname": "de-ber-br-001",
+            "active": False,
+            "ipv4_addr_in": "10.0.0.1",
+            "socks_name": "de-ber-br-socks5-001.relays.mullvad.net",
+            "socks_port": 1080,
+            "type": "bridge",
+            "country_code": "de",
+            "city_name": "Berlin",
+        },
+    ]
+
+    def test_fetches_active_relays_only(self):
+        with patch("mullvad_exit_probe.requests") as mock_req:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = self.SAMPLE_RELAYS
+            mock_resp.raise_for_status = MagicMock()
+            mock_req.get.return_value = mock_resp
+            relays = fetch_relays()
+        assert len(relays) == 1
+        assert relays[0]["hostname"] == "us-mkc-wg-001"
+
+    def test_relay_has_socks_fields(self):
+        with patch("mullvad_exit_probe.requests") as mock_req:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = self.SAMPLE_RELAYS
+            mock_resp.raise_for_status = MagicMock()
+            mock_req.get.return_value = mock_resp
+            relays = fetch_relays()
+        assert relays[0]["socks_name"] == "us-mkc-wg-socks5-001.relays.mullvad.net"
+        assert relays[0]["socks_port"] == 1080
+
+
+class TestProbeRelay:
+    def test_probe_returns_exit_ip(self):
+        relay = {
+            "hostname": "us-mkc-wg-001",
+            "ipv4_addr_in": "155.2.191.3",
+            "socks_name": "us-mkc-wg-socks5-001.relays.mullvad.net",
+            "socks_port": 1080,
+        }
+        with patch("mullvad_exit_probe.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = {"ip": "155.2.190.72"}
+            mock_resp.raise_for_status = MagicMock()
+            mock_get.return_value = mock_resp
+            result = probe_relay(relay)
+        assert result == "155.2.190.72"
+        # Verify SOCKS5 proxy was used
+        call_kwargs = mock_get.call_args[1]
+        assert "socks5h://" in call_kwargs["proxies"]["http"]
+
+    def test_probe_returns_none_on_failure(self):
+        relay = {
+            "hostname": "broken-001",
+            "ipv4_addr_in": "10.0.0.1",
+            "socks_name": "broken.relays.mullvad.net",
+            "socks_port": 1080,
+        }
+        with patch("mullvad_exit_probe.requests.get", side_effect=Exception("timeout")):
+            result = probe_relay(relay)
+        assert result is None
+
+
+class TestWriteResults:
+    def test_writes_csv_with_correct_columns(self, tmp_path):
+        results = [
+            {"relay_hostname": "us-mkc-wg-001", "ingress_ip": "155.2.191.3",
+             "exit_ip": "155.2.190.72", "probe_date": "2026-05-03"},
+        ]
+        out = tmp_path / "exit_ips.csv"
+        write_results(results, str(out))
+
+        with open(out) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["exit_ip"] == "155.2.190.72"
+        assert set(reader.fieldnames) == {"relay_hostname", "ingress_ip", "exit_ip", "probe_date"}

--- a/tests/test_rdap_client.py
+++ b/tests/test_rdap_client.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Tests for RDAP client block CIDR extraction."""
+
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+from unittest.mock import patch, MagicMock
+from shared.rdap_client import RDAPClient
+
+
+class TestCheckBlockCidr:
+    """Test check_block_cidr extracts both name and CIDR from RDAP."""
+
+    SAMPLE_RDAP_RESPONSE = {
+        "name": "MULLVAD-US-MKC",
+        "startAddress": "155.2.190.0",
+        "endAddress": "155.2.191.255",
+        "cidr0_cidrs": [
+            {"v4prefix": "155.2.190.0", "length": 23}
+        ],
+        "entities": [
+            {
+                "vcardArray": ["vcard", [
+                    ["fn", {}, "text", "THG Hosting Limited"]
+                ]]
+            }
+        ]
+    }
+
+    def test_returns_name_and_cidr(self, tmp_path):
+        client = RDAPClient(cache_dir=str(tmp_path))
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = self.SAMPLE_RDAP_RESPONSE
+        with patch.object(client.session, "get", return_value=mock_resp):
+            name, cidr = client.check_block_cidr("155.2.191.3")
+        assert name == "MULLVAD-US-MKC"
+        assert cidr == "155.2.190.0/23"
+
+    def test_falls_back_to_start_end_when_no_cidr0(self, tmp_path):
+        response = {
+            "name": "SOME-BLOCK",
+            "startAddress": "10.0.0.0",
+            "endAddress": "10.0.1.255",
+            "entities": []
+        }
+        client = RDAPClient(cache_dir=str(tmp_path))
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = response
+        with patch.object(client.session, "get", return_value=mock_resp):
+            name, cidr = client.check_block_cidr("10.0.0.1")
+        assert name == "SOME-BLOCK"
+        assert cidr == "10.0.0.0/23"
+
+    def test_returns_empty_on_failure(self, tmp_path):
+        client = RDAPClient(cache_dir=str(tmp_path))
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        with patch.object(client.session, "get", return_value=mock_resp):
+            name, cidr = client.check_block_cidr("192.168.1.1")
+        assert name == ""
+        assert cidr == ""
+
+    def test_returns_empty_cidr_when_no_address_fields(self, tmp_path):
+        response = {"name": "ORPHAN-BLOCK", "entities": []}
+        client = RDAPClient(cache_dir=str(tmp_path))
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = response
+        with patch.object(client.session, "get", return_value=mock_resp):
+            name, cidr = client.check_block_cidr("1.2.3.4")
+        assert name == "ORPHAN-BLOCK"
+        assert cidr == ""

--- a/tests/test_vpn_ip_intel.py
+++ b/tests/test_vpn_ip_intel.py
@@ -15,6 +15,7 @@ from vpn_ip_intel import (
     BaseProvider, load_vpn_lookup, normalize_node, compute_prefix_inferred_rows,
     load_scores, join_scores, FIELDS, SCORE_FIELDS,
     SHARED_HOSTING_ASNS, _COUNTRY_ALIASES, _SERVER_TYPE_ALIASES, TODAY,
+    IP_ROLES,
 )
 
 
@@ -640,3 +641,40 @@ class TestScoreJoin:
     def test_load_scores_missing_file(self, tmp_path):
         scores = load_scores(str(tmp_path / "nonexistent.csv"))
         assert scores == {}
+
+
+class TestEgressInferred:
+    """Test egress-inferred role and dedup changes."""
+
+    def test_egress_inferred_in_ip_roles(self):
+        assert "egress-inferred" in IP_ROLES
+
+    def test_dedup_keeps_both_ingress_and_egress(self):
+        """Same IP with different roles should both survive dedup."""
+        nodes = [
+            {"ip": "1.2.3.4", "provider": "mullvad", "ip_role": "ingress"},
+            {"ip": "1.2.3.4", "provider": "mullvad", "ip_role": "egress"},
+        ]
+        seen = set()
+        deduped = []
+        for n in nodes:
+            key = (n["ip"], n["provider"], n["ip_role"])
+            if key not in seen:
+                seen.add(key)
+                deduped.append(n)
+        assert len(deduped) == 2
+
+    def test_dedup_removes_true_duplicates(self):
+        """Same IP, provider, AND role should dedup to one."""
+        nodes = [
+            {"ip": "1.2.3.4", "provider": "mullvad", "ip_role": "ingress"},
+            {"ip": "1.2.3.4", "provider": "mullvad", "ip_role": "ingress"},
+        ]
+        seen = set()
+        deduped = []
+        for n in nodes:
+            key = (n["ip"], n["provider"], n["ip_role"])
+            if key not in seen:
+                seen.add(key)
+                deduped.append(n)
+        assert len(deduped) == 1

--- a/tests/test_vpn_ip_intel.py
+++ b/tests/test_vpn_ip_intel.py
@@ -118,25 +118,16 @@ class TestMullvadProvider:
 
     def test_load_exit_seeds(self, tmp_path):
         """MullvadProvider loads exit IPs from seed CSV when present."""
-        seed_dir = tmp_path / "data" / "vpn_seeds"
-        seed_dir.mkdir(parents=True)
-        seed_csv = seed_dir / "mullvad_exit_ips.csv"
+        seed_csv = tmp_path / "mullvad_exit_ips.csv"
         seed_csv.write_text(
             "relay_hostname,ingress_ip,exit_ip,probe_date\n"
             "us-mkc-wg-001,155.2.191.3,155.2.190.72,2026-05-03\n"
             "se-got-wg-001,185.213.154.68,185.213.154.100,2026-05-03\n"
         )
 
-        import vpn_ip_intel
-        original = vpn_ip_intel.__file__
-        scripts_dir = tmp_path / "scripts"
-        scripts_dir.mkdir()
-        try:
-            vpn_ip_intel.__file__ = str(scripts_dir / "vpn_ip_intel.py")
-            provider = MullvadProvider()
-            egress_nodes = provider.load_exit_seeds()
-        finally:
-            vpn_ip_intel.__file__ = original
+        provider = MullvadProvider()
+        provider.SEED_PATH = str(seed_csv)
+        egress_nodes = provider.load_exit_seeds()
 
         assert len(egress_nodes) == 2
         assert egress_nodes[0]["ip"] == "155.2.190.72"
@@ -147,16 +138,9 @@ class TestMullvadProvider:
 
     def test_load_exit_seeds_missing_file(self, tmp_path):
         """Returns empty list when seed file doesn't exist."""
-        import vpn_ip_intel
-        original = vpn_ip_intel.__file__
-        scripts_dir = tmp_path / "scripts"
-        scripts_dir.mkdir()
-        try:
-            vpn_ip_intel.__file__ = str(scripts_dir / "vpn_ip_intel.py")
-            provider = MullvadProvider()
-            egress_nodes = provider.load_exit_seeds()
-        finally:
-            vpn_ip_intel.__file__ = original
+        provider = MullvadProvider()
+        provider.SEED_PATH = str(tmp_path / "nonexistent.csv")
+        egress_nodes = provider.load_exit_seeds()
         assert egress_nodes == []
 
 

--- a/tests/test_vpn_ip_intel.py
+++ b/tests/test_vpn_ip_intel.py
@@ -13,6 +13,7 @@ from vpn_ip_intel import (
     MullvadProvider, NordVPNProvider, ProtonVPNProvider, AstrillProvider,
     UrbanVPNProvider,
     BaseProvider, load_vpn_lookup, normalize_node, compute_prefix_inferred_rows,
+    compute_rdap_egress_rows,
     load_scores, join_scores, FIELDS, SCORE_FIELDS,
     SHARED_HOSTING_ASNS, _COUNTRY_ALIASES, _SERVER_TYPE_ALIASES, TODAY,
     IP_ROLES,
@@ -721,3 +722,83 @@ class TestEgressInferred:
                 seen.add(key)
                 deduped.append(n)
         assert len(deduped) == 1
+
+
+class TestRDAPEgressExpansion:
+    """Test RDAP-based egress prefix expansion."""
+
+    def _make_ingress_nodes(self, ips, provider="mullvad", asn="AS13213"):
+        return [
+            {"ip": ip, "provider": provider, "confidence": "confirmed",
+             "country": "US", "city": "Kansas City, MO", "server_type": "wireguard",
+             "asn": asn, "asn_name": "UK2NET-AS, GB", "source": "mullvad_api",
+             "source_date": TODAY, "hostname": f"us-mkc-wg-{i:03d}",
+             "collection_method": "Public API",
+             "threat_relevance": "Verified no-logs", "ip_role": "ingress", "prefix": "",
+             "score_prehire": "8", "tier_prehire": "contextual",
+             "score_posthire": "8", "tier_posthire": "contextual",
+             "indicator_id": "VPN-007"}
+            for i, ip in enumerate(ips, 1)
+        ]
+
+    @patch("vpn_ip_intel.RDAPClient")
+    def test_expands_adjacent_prefixes(self, MockRDAP):
+        """If RDAP says 155.2.190.0/23 is one block, and we have IPs in 155.2.191.0/24,
+        then 155.2.190.0/24 should get an egress-inferred row."""
+        mock_client = MockRDAP.return_value
+        mock_client.check_block_cidr.return_value = ("MULLVAD-US-MKC", "155.2.190.0/23")
+
+        nodes = self._make_ingress_nodes([
+            "155.2.191.3", "155.2.191.53", "155.2.191.103", "155.2.191.153"
+        ])
+        result = compute_rdap_egress_rows(nodes, rdap=mock_client)
+
+        assert len(result) == 1
+        assert result[0]["ip"] == ""
+        assert result[0]["prefix"] == "155.2.190.0/24"
+        assert result[0]["ip_role"] == "egress-inferred"
+        assert result[0]["confidence"] == "medium"
+        assert result[0]["source"] == "rdap_prefix_expansion"
+        assert result[0]["provider"] == "mullvad"
+
+    @patch("vpn_ip_intel.RDAPClient")
+    def test_skips_shared_hosting_asns(self, MockRDAP):
+        mock_client = MockRDAP.return_value
+        nodes = self._make_ingress_nodes(
+            ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"],
+            asn="AS16509"  # AWS
+        )
+        result = compute_rdap_egress_rows(nodes, rdap=mock_client)
+        assert len(result) == 0
+        mock_client.check_block_cidr.assert_not_called()
+
+    @patch("vpn_ip_intel.RDAPClient")
+    def test_skips_prefix_already_covered(self, MockRDAP):
+        """If we already have IPs in a /24, don't emit an egress-inferred row for it."""
+        mock_client = MockRDAP.return_value
+        mock_client.check_block_cidr.return_value = ("BLOCK", "10.0.0.0/23")
+
+        nodes = self._make_ingress_nodes(["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"])
+        nodes.extend(self._make_ingress_nodes(["10.0.1.1", "10.0.1.2", "10.0.1.3", "10.0.1.4"]))
+        result = compute_rdap_egress_rows(nodes, rdap=mock_client)
+        assert len(result) == 0
+
+    @patch("vpn_ip_intel.RDAPClient")
+    def test_no_expansion_when_rdap_fails(self, MockRDAP):
+        mock_client = MockRDAP.return_value
+        mock_client.check_block_cidr.return_value = ("", "")
+
+        nodes = self._make_ingress_nodes(["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"])
+        result = compute_rdap_egress_rows(nodes, rdap=mock_client)
+        assert len(result) == 0
+
+    @patch("vpn_ip_intel.RDAPClient")
+    def test_only_processes_ingress_nodes(self, MockRDAP):
+        """Nodes with ip_role != ingress should not trigger expansion."""
+        mock_client = MockRDAP.return_value
+        nodes = self._make_ingress_nodes(["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"])
+        for n in nodes:
+            n["ip_role"] = "egress"
+        result = compute_rdap_egress_rows(nodes, rdap=mock_client)
+        assert len(result) == 0
+        mock_client.check_block_cidr.assert_not_called()

--- a/tests/test_vpn_ip_intel.py
+++ b/tests/test_vpn_ip_intel.py
@@ -115,6 +115,49 @@ class TestMullvadProvider:
             nodes = provider.fetch()
         assert len(nodes) == 0
 
+    def test_load_exit_seeds(self, tmp_path):
+        """MullvadProvider loads exit IPs from seed CSV when present."""
+        seed_dir = tmp_path / "data" / "vpn_seeds"
+        seed_dir.mkdir(parents=True)
+        seed_csv = seed_dir / "mullvad_exit_ips.csv"
+        seed_csv.write_text(
+            "relay_hostname,ingress_ip,exit_ip,probe_date\n"
+            "us-mkc-wg-001,155.2.191.3,155.2.190.72,2026-05-03\n"
+            "se-got-wg-001,185.213.154.68,185.213.154.100,2026-05-03\n"
+        )
+
+        import vpn_ip_intel
+        original = vpn_ip_intel.__file__
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        try:
+            vpn_ip_intel.__file__ = str(scripts_dir / "vpn_ip_intel.py")
+            provider = MullvadProvider()
+            egress_nodes = provider.load_exit_seeds()
+        finally:
+            vpn_ip_intel.__file__ = original
+
+        assert len(egress_nodes) == 2
+        assert egress_nodes[0]["ip"] == "155.2.190.72"
+        assert egress_nodes[0]["ip_role"] == "egress"
+        assert egress_nodes[0]["confidence"] == "confirmed"
+        assert egress_nodes[0]["source"] == "socks5_probe"
+        assert egress_nodes[0]["hostname"] == "us-mkc-wg-001"
+
+    def test_load_exit_seeds_missing_file(self, tmp_path):
+        """Returns empty list when seed file doesn't exist."""
+        import vpn_ip_intel
+        original = vpn_ip_intel.__file__
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        try:
+            vpn_ip_intel.__file__ = str(scripts_dir / "vpn_ip_intel.py")
+            provider = MullvadProvider()
+            egress_nodes = provider.load_exit_seeds()
+        finally:
+            vpn_ip_intel.__file__ = original
+        assert egress_nodes == []
+
 
 class TestNordVPNProvider:
     SAMPLE_API_RESPONSE = [


### PR DESCRIPTION
## Summary
- **RDAP prefix expansion**: Infers egress /24 prefixes for all ingress-only VPN providers by querying RDAP for allocated blocks. Found 688 inferred exit /24 blocks for Mullvad alone on first run.
- **SOCKS5 exit probe**: New standalone script (`mullvad_exit_probe.py`) discovers true exit IPs by connecting through each relay's SOCKS5 proxy to `am.i.mullvad.net`. Run manually when Mullvad is connected.
- **Seed loading**: `MullvadProvider` automatically loads probe results from `data/vpn_seeds/mullvad_exit_ips.csv` on next CI run.
- **Data model**: New `egress-inferred` IP role, updated dedup key to `(ip, provider, ip_role)` so an IP can appear as both ingress and egress.

Closes the gap where Spur identifies Mullvad exit IPs (e.g. 155.2.190.72) that our pipeline missed because the Mullvad API only exposes ingress IPs (`ipv4_addr_in`).

## Test plan
- [x] 78 unit tests passing (new: RDAP CIDR extraction, egress expansion, seed loading, probe script, dedup)
- [x] Integration dry-run: `vpn_ip_intel.py --providers mullvad` completes successfully
- [x] RDAP expansion produces egress-inferred rows
- [ ] Run `mullvad_exit_probe.py --limit 5` with Mullvad connected to verify SOCKS5 probing

🤖 Generated with [Claude Code](https://claude.com/claude-code)