### PR TITLE
fix: stop silent domain drops in shard pipeline; enforce reconciliation

### DIFF
--- a/.github/workflows/update_intelligence.yml
+++ b/.github/workflows/update_intelligence.yml
@@ -211,8 +211,10 @@ jobs:
 
       - name: Merge Results
         run: |
-          # Merges all result_part_*.csv into dea_domains_probed.csv
-          python scripts/merge_results.py --pattern "data/result_part_*.csv" --output data/dea_domains_probed.csv
+          # Merges all result_part_*.csv into dea_domains_probed.csv and
+          # reconciles the merged domain set against the pipeline input —
+          # fails the run loudly if any shard silently lost domains.
+          python scripts/merge_results.py --pattern "data/result_part_*.csv" --output data/dea_domains_probed.csv --expect-input data/pipeline_input.csv
 
           # Shodan enrichment moved to AFTER triage to save time/credits.
           # Was causing 3+ hour runtimes on full dataset.

--- a/scripts/enrich_infrastructure.py
+++ b/scripts/enrich_infrastructure.py
@@ -9,6 +9,13 @@ Architecture:
 - Async Producer-Consumer pattern (or massive gather with Semaphore)
 - dns.asyncresolver for non-blocking DNS
 - Team Cymru IP-to-ASN mapping
+
+Completeness contract: every input domain produces exactly one output row.
+Domains that cannot be enriched are written with an explanatory ``error``
+column instead of being dropped. Transient DNS failures (timeout, SERVFAIL)
+are retried with backoff before being recorded; NXDOMAIN is permanent and
+recorded without retry. The run reconciles output against input and exits
+non-zero on any mismatch.
 """
 
 import argparse
@@ -17,10 +24,11 @@ import asyncio
 import dns.asyncresolver
 import dns.resolver
 import dns.reversename
+import dns.exception
 import sys
 import os
 import time
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 from tqdm.asyncio import tqdm_asyncio
 from vpn_ip_intel import load_vpn_lookup
 
@@ -30,46 +38,110 @@ DEFAULT_TIMEOUT = 4.0
 DEFAULT_LIFETIME = 8.0
 MAX_CONCURRENCY = 200 # Default connections
 
+RETRY_MAX_ATTEMPTS = 3    # attempts per DNS query on transient failures
+RETRY_BACKOFF_BASE = 2.0  # delay = base ** (attempt - 1) seconds between attempts
+
+# Transient: worth retrying now and worth re-attempting on the next run
+# (timeouts, SERVFAIL/"all nameservers failed"). Permanent: authoritative
+# "name does not exist" (NXDOMAIN). NoAnswer means the name exists but has no
+# record of the requested type — that is empty data, not an error.
+TRANSIENT_DNS_EXCEPTIONS = (dns.exception.Timeout, dns.resolver.NoNameservers)
+
 _DEADLINE = None  # Global deadline timestamp (set by main via --timeout-minutes)
 
 # VPN exit IP lookup for risk tagging
 _vpn_lookup = load_vpn_lookup()
 
+
+class TransientDNSError(Exception):
+    """A DNS lookup that still failed with a retryable error after all attempts."""
+
+
+def _past_deadline() -> bool:
+    return _DEADLINE is not None and time.time() > _DEADLINE
+
+
+def reconcile_or_die(input_domains: Set[str], output_domains: Set[str],
+                     label: str = "enrich_infrastructure") -> None:
+    """Assert the output domain set equals the input domain set.
+
+    Prints the mismatch (count + sample) and exits non-zero — a shard that
+    lost domains must fail its CI job, not report success.
+    """
+    missing = sorted(input_domains - output_domains)
+    extra = sorted(output_domains - input_domains)
+    if not missing and not extra:
+        print(f"[RECONCILE] OK ({label}): {len(output_domains)} output domains == "
+              f"{len(input_domains)} input domains")
+        return
+    if missing:
+        print(f"[RECONCILE] FAIL ({label}): {len(missing)} input domains missing "
+              f"from output. Sample: {missing[:10]}")
+    if extra:
+        print(f"[RECONCILE] FAIL ({label}): {len(extra)} unexpected domains in "
+              f"output. Sample: {extra[:10]}")
+    sys.exit(1)
+
+
 class AsyncResolver:
-    def __init__(self, nameservers: List[str] = None):
+    def __init__(self, nameservers: List[str] = None, max_attempts: int = 1):
+        """max_attempts=1 fails fast on transient errors (bulk first pass);
+        the retry sweep uses a second instance with max_attempts > 1.
+        Inline per-query retries are deliberately NOT the default: on this
+        dataset a large fraction of domains have dead nameservers, and
+        retrying them inline multiplies dead time per semaphore slot and
+        collapses shard throughput."""
         self.resolver = dns.asyncresolver.Resolver()
         if nameservers:
             self.resolver.nameservers = nameservers
-        
+
         self.resolver.timeout = DEFAULT_TIMEOUT
         self.resolver.lifetime = DEFAULT_LIFETIME
+        self.max_attempts = max_attempts
+
+    async def _query(self, qname: str, rdtype: str):
+        """One DNS query with bounded retries on transient failures.
+
+        Raises TransientDNSError once attempts are exhausted (or the global
+        deadline has passed — no point backing off into a dead run). Permanent
+        outcomes (NXDOMAIN, NoAnswer) propagate for the caller to classify.
+        """
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                return await self.resolver.resolve(qname, rdtype)
+            except TRANSIENT_DNS_EXCEPTIONS as e:
+                if attempt >= self.max_attempts or _past_deadline():
+                    raise TransientDNSError(f"{rdtype}:{type(e).__name__}") from e
+                await asyncio.sleep(RETRY_BACKOFF_BASE ** (attempt - 1))
 
     async def resolve_mx(self, domain: str) -> List[Tuple[int, str]]:
         """Returns sorted list of (priority, hostname) tuples."""
         try:
-            answers = await self.resolver.resolve(domain, 'MX')
-            records = sorted([(r.preference, str(r.exchange).strip('.')) for r in answers], key=lambda x: x[0])
-            return records
-        except Exception:
+            answers = await self._query(domain, 'MX')
+        except dns.resolver.NoAnswer:
             return []
+        return sorted([(r.preference, str(r.exchange).strip('.')) for r in answers],
+                      key=lambda x: x[0])
 
     async def resolve_ns(self, domain: str) -> List[str]:
         """Returns sorted list of Name Servers."""
         try:
-            answers = await self.resolver.resolve(domain, 'NS')
-            return sorted([str(r.target).strip('.').lower() for r in answers])
-        except Exception:
+            answers = await self._query(domain, 'NS')
+        except dns.resolver.NoAnswer:
             return []
+        return sorted([str(r.target).strip('.').lower() for r in answers])
 
     async def resolve_a(self, hostname: str) -> str:
         """Returns the first A record IP address."""
         if not hostname: return ""
         try:
-            answers = await self.resolver.resolve(hostname, 'A')
-            for r in answers:
-                return r.to_text()
-        except Exception:
+            answers = await self._query(hostname, 'A')
+        except dns.resolver.NoAnswer:
             return ""
+        for r in answers:
+            return r.to_text()
         return ""
 
     async def resolve_asn(self, ip_address: str) -> Dict[str, str]:
@@ -78,25 +150,25 @@ class AsyncResolver:
         """
         if not ip_address:
             return {}
-            
+
+        rev_name = dns.reversename.from_address(ip_address)
+        reversed_ip = str(rev_name).lower().replace('.in-addr.arpa.', '')
+        query = f"{reversed_ip}.{CYMRU_ASN_SUFFIX}"
+
         try:
-            rev_name = dns.reversename.from_address(ip_address)
-            reversed_ip = str(rev_name).lower().replace('.in-addr.arpa.', '')
-            query = f"{reversed_ip}.{CYMRU_ASN_SUFFIX}"
-            
-            answers = await self.resolver.resolve(query, 'TXT')
-            for r in answers:
-                txt = r.to_text().strip('"')
-                parts = [p.strip() for p in txt.split('|')]
-                if len(parts) >= 1:
-                    return {
-                        "asn": parts[0],
-                        "bgp_prefix": parts[1] if len(parts) > 1 else "",
-                        "cc": parts[2] if len(parts) > 2 else "",
-                        "registry": parts[3] if len(parts) > 3 else ""
-                    }
-        except Exception:
-            pass
+            answers = await self._query(query, 'TXT')
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+            return {}  # unrouted/unknown IP — normal, not an error
+        for r in answers:
+            txt = r.to_text().strip('"')
+            parts = [p.strip() for p in txt.split('|')]
+            if len(parts) >= 1:
+                return {
+                    "asn": parts[0],
+                    "bgp_prefix": parts[1] if len(parts) > 1 else "",
+                    "cc": parts[2] if len(parts) > 2 else "",
+                    "registry": parts[3] if len(parts) > 3 else ""
+                }
         return {}
 
     async def resolve_asn_name(self, asn: str) -> str:
@@ -105,17 +177,17 @@ class AsyncResolver:
         Query: AS<ASN>.asn.cymru.com TXT
         """
         if not asn: return ""
+        query = f"AS{asn}.asn.cymru.com"
         try:
-            query = f"AS{asn}.asn.cymru.com"
-            answers = await self.resolver.resolve(query, 'TXT')
-            for r in answers:
-                txt = r.to_text().strip('"')
-                parts = [p.strip() for p in txt.split('|')]
-                # "15169 | US | arin | 2000-03-30 | GOOGLE"
-                if len(parts) >= 5:
-                    return parts[4]
-        except Exception:
-            pass
+            answers = await self._query(query, 'TXT')
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+            return ""
+        for r in answers:
+            txt = r.to_text().strip('"')
+            parts = [p.strip() for p in txt.split('|')]
+            # "15169 | US | arin | 2000-03-30 | GOOGLE"
+            if len(parts) >= 5:
+                return parts[4]
         return ""
 
 async def process_domain(sem: asyncio.Semaphore, resolver: AsyncResolver, domain: str) -> Dict:
@@ -137,13 +209,29 @@ async def process_domain(sem: asyncio.Semaphore, resolver: AsyncResolver, domain
             "risk_tags": "",
             "error": ""
         }
-        
+
+        # Past the deadline, emit an accounted row instead of starting lookups.
+        # The previous behavior (break out of the collection loop and write only
+        # completed rows) silently dropped every unprocessed domain in the shard.
+        if _past_deadline():
+            result["error"] = "deadline_exceeded"
+            return result
+
+        transient: List[str] = []
+        nxdomain = False
+
         try:
             # 1. Resolve NS (New for Nicenic Detection)
-            ns_records = await resolver.resolve_ns(domain)
+            ns_records: List[str] = []
+            try:
+                ns_records = await resolver.resolve_ns(domain)
+            except dns.resolver.NXDOMAIN:
+                nxdomain = True
+            except TransientDNSError as e:
+                transient.append(f"ns:{e}")
             if ns_records:
                 result["nameservers"] = ";".join(ns_records)
-                
+
                 # Check for High Risk Registrars (Nicenic)
                 # Defined signals: nicendns.com, jpisp.com
                 for ns in ns_records:
@@ -152,14 +240,23 @@ async def process_domain(sem: asyncio.Semaphore, resolver: AsyncResolver, domain
                         break
 
             # 2. Resolve A record of domain itself (web hosting IP)
-            a_ip = await resolver.resolve_a(domain)
+            a_ip = ""
+            try:
+                a_ip = await resolver.resolve_a(domain)
+            except dns.resolver.NXDOMAIN:
+                nxdomain = True
+            except TransientDNSError as e:
+                transient.append(f"a:{e}")
             if a_ip:
                 result["a_record"] = a_ip
-                a_asn_data = await resolver.resolve_asn(a_ip)
-                a_asn = a_asn_data.get("asn", "")
-                if a_asn:
-                    result["a_record_asn"] = a_asn
-                    result["a_record_asn_name"] = await resolver.resolve_asn_name(a_asn)
+                try:
+                    a_asn_data = await resolver.resolve_asn(a_ip)
+                    a_asn = a_asn_data.get("asn", "")
+                    if a_asn:
+                        result["a_record_asn"] = a_asn
+                        result["a_record_asn_name"] = await resolver.resolve_asn_name(a_asn)
+                except TransientDNSError as e:
+                    transient.append(f"a_asn:{e}")
 
                 # VPN exit node tagging
                 if a_ip in _vpn_lookup:
@@ -168,31 +265,56 @@ async def process_domain(sem: asyncio.Semaphore, resolver: AsyncResolver, domain
                     result["risk_tags"] = f"{existing};{vpn_tag}" if existing else vpn_tag
 
             # 3. Resolve MX
-            mxs = await resolver.resolve_mx(domain)
+            mxs: List[Tuple[int, str]] = []
+            try:
+                mxs = await resolver.resolve_mx(domain)
+            except dns.resolver.NXDOMAIN:
+                nxdomain = True
+            except TransientDNSError as e:
+                transient.append(f"mx:{e}")
             if mxs:
                 result["mx_records"] = ";".join([f"{p} {h}" for p, h in mxs])
                 result["primary_mx"] = mxs[0][1]
-                
+
                 # 4. Resolve A Record of Primary MX
-                ip = await resolver.resolve_a(result["primary_mx"])
+                ip = ""
+                try:
+                    ip = await resolver.resolve_a(result["primary_mx"])
+                except dns.resolver.NXDOMAIN:
+                    ip = ""  # the MX host not existing is not the domain's NXDOMAIN
+                except TransientDNSError as e:
+                    transient.append(f"mx_a:{e}")
                 result["mx_ip"] = ip
 
                 # 5. Resolve ASN of IP
                 if ip:
-                    asn_data = await resolver.resolve_asn(ip)
-                    result.update(asn_data)
+                    try:
+                        asn_data = await resolver.resolve_asn(ip)
+                        result.update(asn_data)
 
-                    # 6. Resolve ASN Name (Optional, adds time)
-                    # To be super fast, we might skip this or do it only if ASN found
-                    if result.get("asn"):
-                        result["asn_name"] = await resolver.resolve_asn_name(result["asn"])
+                        # 6. Resolve ASN Name (Optional, adds time)
+                        # To be super fast, we might skip this or do it only if ASN found
+                        if result.get("asn"):
+                            result["asn_name"] = await resolver.resolve_asn_name(result["asn"])
+                    except TransientDNSError as e:
+                        transient.append(f"mx_asn:{e}")
 
         except Exception as e:
-            result["error"] = str(e)
-            
+            # Unexpected failure (malformed name, library error): record it,
+            # never drop the row.
+            result["error"] = str(e) or type(e).__name__
+            return result
+
+        has_data = bool(result["nameservers"] or result["a_record"] or result["mx_records"])
+        if transient:
+            result["error"] = "transient:" + ";".join(transient)
+        elif nxdomain and not has_data:
+            result["error"] = "NXDOMAIN"
+
         return result
 
-async def runner(input_file: str, output_file: str, concurrency: int, limit: int = 0):
+async def runner(input_file: str, output_file: str, concurrency: int, limit: int = 0,
+                 nameservers: List[str] = None):
     # Read domains
     domains = []
     print(f"[*] Reading {input_file}...")
@@ -220,35 +342,102 @@ async def runner(input_file: str, output_file: str, concurrency: int, limit: int
         print(f"[*] Limiting to first {limit} domains.")
         domains = domains[:limit]
 
-    print(f"[*] Enriched {len(domains)} domains with concurrency={concurrency}...")
-    
+    # One task (and one output row) per unique domain, preserving input order.
+    seen: Set[str] = set()
+    unique_domains: List[str] = []
+    for d in domains:
+        if d not in seen:
+            seen.add(d)
+            unique_domains.append(d)
+    if len(unique_domains) != len(domains):
+        print(f"[*] Skipping {len(domains) - len(unique_domains)} duplicate input rows.")
+
+    print(f"[*] Enriching {len(unique_domains)} domains with concurrency={concurrency}...")
+
     # Setup Async
-    resolver = AsyncResolver()
+    resolver = AsyncResolver(nameservers=nameservers)
     sem = asyncio.Semaphore(concurrency)
-    
-    tasks = [process_domain(sem, resolver, d) for d in domains]
-    
+
+    tasks = [process_domain(sem, resolver, d) for d in unique_domains]
+
     results = []
-    # Use tqdm to show progress of completed futures
+    # No deadline break here: once the deadline passes, process_domain
+    # short-circuits every remaining task into a fast "deadline_exceeded" row,
+    # so the tail drains as error rows instead of being dropped.
     for f in tqdm_asyncio.as_completed(tasks, total=len(tasks), unit="dom"):
         res = await f
         results.append(res)
-        if _DEADLINE is not None and time.time() > _DEADLINE:
-            print(f"\n[!] Timeout reached. Processed {len(results)}/{len(tasks)} domains. Writing partial results.")
-            break
-        
-    # Write output
+
+    by_domain = {r["domain"]: r for r in results}
+
+    # Retry sweep: re-attempt transient failures with backoff, but only in
+    # whatever budget remains after the main pass. Keeping retries out of the
+    # first pass preserves bulk throughput.
+    transient_failed = [d for d in unique_domains
+                        if by_domain[d].get("error", "").startswith("transient:")]
+    if transient_failed and not _past_deadline():
+        print(f"\n[*] Retry sweep: {len(transient_failed)} domains with transient "
+              f"failures, up to {RETRY_MAX_ATTEMPTS - 1} more attempts each...")
+        retry_resolver = AsyncResolver(nameservers=nameservers,
+                                       max_attempts=RETRY_MAX_ATTEMPTS)
+        retry_tasks = [process_domain(sem, retry_resolver, d) for d in transient_failed]
+        for f in tqdm_asyncio.as_completed(retry_tasks, total=len(retry_tasks), unit="dom"):
+            r2 = await f
+            # A deadline row means the sweep ran out of time before this domain
+            # was re-attempted — keep the original transient row in that case.
+            if r2.get("error", "") != "deadline_exceeded":
+                by_domain[r2["domain"]] = r2
+    # Belt and braces: a domain whose task produced no result still gets a row.
+    for d in unique_domains:
+        if d not in by_domain:
+            by_domain[d] = {"domain": d, "error": "internal:no_result"}
+
+    n_deadline = sum(1 for r in by_domain.values() if r.get("error") == "deadline_exceeded")
+    if n_deadline:
+        print(f"\n[!] Deadline reached: {n_deadline}/{len(unique_domains)} domains not "
+              f"enriched; error rows written instead of dropping them.")
+
+    # Write output — one row per input domain, in input order.
     print(f"[*] Writing results to {output_file}...")
     headers = ["domain", "primary_mx", "mx_ip", "asn", "asn_name", "bgp_prefix", "cc", "registry", "mx_records", "nameservers", "a_record", "a_record_asn", "a_record_asn_name", "risk_tags", "error"]
-    
+
     with open(output_file, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=headers)
         writer.writeheader()
-        for r in results:
-            # Clean dict
+        for d in unique_domains:
+            r = by_domain[d]
             row_out = {h: r.get(h, "") for h in headers}
             writer.writerow(row_out)
-            
+
+    # Reconcile what actually landed on disk against the input. This is the
+    # check that would have caught the missing-prefix incident on day one.
+    written: Set[str] = set()
+    with open(output_file, "r", newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            written.add(row["domain"])
+    reconcile_or_die(set(unique_domains), written)
+
+    counts = {"succeeded": 0, "permanent_nxdomain": 0, "transient_after_retries": 0,
+              "deadline_unprocessed": 0, "other_errors": 0}
+    for d in unique_domains:
+        err = by_domain[d].get("error", "")
+        if not err:
+            counts["succeeded"] += 1
+        elif err == "NXDOMAIN":
+            counts["permanent_nxdomain"] += 1
+        elif err.startswith("transient:"):
+            counts["transient_after_retries"] += 1
+        elif err == "deadline_exceeded":
+            counts["deadline_unprocessed"] += 1
+        else:
+            counts["other_errors"] += 1
+    print(f"[SUMMARY] input={len(domains)} output={len(unique_domains)} "
+          f"succeeded={counts['succeeded']} "
+          f"permanent_nxdomain={counts['permanent_nxdomain']} "
+          f"transient_after_retries={counts['transient_after_retries']} "
+          f"deadline_unprocessed={counts['deadline_unprocessed']} "
+          f"other_errors={counts['other_errors']}")
+
     print("[*] Done.")
 
 def main():
@@ -259,6 +448,9 @@ def main():
     parser.add_argument("--limit", type=int, default=0)
     parser.add_argument("--timeout-minutes", type=int, default=0,
                         help="Global time budget in minutes. 0 = unlimited (default).")
+    parser.add_argument("--nameservers", default=None,
+                        help="Comma-separated resolver IPs (e.g. 1.1.1.1,8.8.8.8). "
+                             "Default: system resolver.")
 
     args = parser.parse_args()
 
@@ -269,8 +461,9 @@ def main():
 
     if sys.platform == 'win32':
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        
-    asyncio.run(runner(args.input, args.output, args.workers, args.limit))
+
+    nameservers = [n.strip() for n in args.nameservers.split(",") if n.strip()] if args.nameservers else None
+    asyncio.run(runner(args.input, args.output, args.workers, args.limit, nameservers))
 
 if __name__ == "__main__":
     main()

--- a/scripts/enrich_reputation.py
+++ b/scripts/enrich_reputation.py
@@ -15,6 +15,7 @@ import argparse
 import logging
 import os
 import csv
+import sys
 import dns.resolver
 import dns.exception
 import requests
@@ -24,6 +25,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Optional
 from tqdm import tqdm
 from shared.sanitize import sanitize_csv_value
+from shared.rowutil import append_error
 
 logger = logging.getLogger(__name__)
 
@@ -268,8 +270,10 @@ _DEADLINE = None  # Global deadline timestamp (set by main via --timeout-minutes
 
 
 def process_one(row: Dict) -> Dict:
-    # If we've exceeded the time budget, return the row unprocessed
+    # If we've exceeded the time budget, return the row unprocessed but
+    # annotated, so downstream consumers can tell "not enriched" from "empty".
     if _DEADLINE is not None and time.time() > _DEADLINE:
+        append_error(row, "reputation:deadline_exceeded")
         return row
 
     resolver = dns.resolver.Resolver()
@@ -330,6 +334,8 @@ def main():
     for c in new_cols:
         if c not in fieldnames:
             fieldnames.append(c)
+    if "error" not in fieldnames:
+        fieldnames.append("error")
 
     print(f"[*] Processing {len(rows)} domains for reputation/age with {args.workers} workers...")
 
@@ -346,16 +352,32 @@ def main():
             results.append(res)
             if _DEADLINE is not None and time.time() > _DEADLINE:
                 print(f"\n[!] Timeout reached. Processed {len(results)}/{len(rows)} domains. Writing partial results.")
-                # Append remaining unprocessed rows as-is
+                # Append remaining unprocessed rows, annotated so the skip is visible
                 remaining_rows = rows[len(results):]
+                for r in remaining_rows:
+                    append_error(r, "reputation:deadline_exceeded")
                 results.extend(remaining_rows)
                 break
+
+    # Reconcile: this stage must never drop or invent rows.
+    in_domains = {r.get("domain", "") for r in rows}
+    out_domains = {r.get("domain", "") for r in results}
+    if len(results) != len(rows) or in_domains != out_domains:
+        missing = sorted(in_domains - out_domains)
+        print(f"[RECONCILE] FAIL (enrich_reputation): output {len(results)} rows vs "
+              f"input {len(rows)} rows. Sample missing: {missing[:10]}")
+        sys.exit(1)
+    print(f"[RECONCILE] OK (enrich_reputation): {len(results)} rows out == {len(rows)} rows in")
 
     with open(args.output, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(results)
 
+    n_skipped = sum(1 for r in results
+                    if "reputation:deadline_exceeded" in (r.get("error") or ""))
+    print(f"[SUMMARY] input={len(rows)} output={len(results)} "
+          f"enriched={len(results) - n_skipped} deadline_passthrough={n_skipped}")
     print(f"[*] Done. Saved to {args.output}")
 
 if __name__ == "__main__":

--- a/scripts/merge_results.py
+++ b/scripts/merge_results.py
@@ -5,28 +5,57 @@ merge_results.py
 Merges multiple CSV shards into a single file.
 Assumes all shards have the same header.
 Usage: python merge_results.py --pattern "data/result_part_*.csv" --output data/result_final.csv
+
+With --expect-input, the merged output's domain set is reconciled against the
+given input CSV and the merge exits non-zero on any mismatch — a run that lost
+domains must fail loudly, not report success.
 """
 
 import argparse
 import csv
 import glob
 import os
+import sys
+
+
+def _read_domain_set(path: str) -> set:
+    """Read the set of domains from a CSV with a 'domain' column (or a plain list)."""
+    domains = set()
+    with open(path, "r", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames and "domain" in reader.fieldnames:
+            for row in reader:
+                if row.get("domain"):
+                    domains.add(row["domain"])
+        else:
+            f.seek(0)
+            for line in f:
+                d = line.strip()
+                if d and not d.startswith("#") and d.lower() != "domain":
+                    domains.add(d)
+    return domains
+
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--pattern", required=True, help="Glob pattern for input files")
     parser.add_argument("--output", required=True, help="Output merged CSV file")
+    parser.add_argument("--expect-input", default=None,
+                        help="CSV of expected domains; after merging, assert the output "
+                             "domain set equals this set and exit 1 otherwise.")
     args = parser.parse_args()
 
     files = sorted(glob.glob(args.pattern))
     if not files:
         print(f"[!] No files found matching {args.pattern}")
-        return
+        sys.exit(1)
 
     print(f"[*] Found {len(files)} files to merge.")
 
     header = None
     total_rows = 0
+    merged_domains = set()
+    failed_files = []
 
     # Columns that should be present in merged output for schema consistency
     REQUIRED_COLUMNS = ["flame_tp_ids"]
@@ -57,12 +86,36 @@ def main():
                     for row in reader:
                         out_row = {col: row.get(col, "") for col in header}
                         writer.writerow(out_row)
+                        merged_domains.add(row.get("domain", ""))
                         total_rows += 1
 
             except Exception as e:
+                # A shard that cannot be read means lost domains — never continue silently.
                 print(f"\n[!] Error reading {file_path}: {e}")
+                failed_files.append(file_path)
 
     print(f"\n[*] Merged {total_rows} rows into {args.output}")
+
+    if failed_files:
+        print(f"[!] {len(failed_files)} shard file(s) failed to read: {failed_files}")
+        sys.exit(1)
+
+    if args.expect_input:
+        expected = _read_domain_set(args.expect_input)
+        missing = sorted(expected - merged_domains)
+        extra = sorted(merged_domains - expected)
+        if missing or extra:
+            if missing:
+                print(f"[RECONCILE] FAIL: {len(missing)} expected domains missing from "
+                      f"merged output. Sample: {missing[:10]}")
+            if extra:
+                print(f"[RECONCILE] FAIL: {len(extra)} unexpected domains in merged "
+                      f"output. Sample: {extra[:10]}")
+            sys.exit(1)
+        print(f"[RECONCILE] OK: merged output covers all {len(expected)} expected domains exactly.")
+        print(f"[SUMMARY] shards={len(files)} rows={total_rows} expected={len(expected)} "
+              f"missing=0 extra=0")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/probe_web.py
+++ b/scripts/probe_web.py
@@ -15,6 +15,8 @@ import aiohttp
 import sys
 from typing import Dict, Any, List
 
+from shared.rowutil import append_error
+
 # Explicit Research User-Agent (Best Practice)
 USER_AGENT = "DomainIntelResearch/1.0 (+https://github.com/elchacal801/domain_intel; contact: open-issue-on-repo)"
 
@@ -69,7 +71,8 @@ async def fetch(session: aiohttp.ClientSession, url: str, proxy: str = None) -> 
         
     return result
 
-async def worker(queue: asyncio.Queue, session: aiohttp.ClientSession, proxy: str):
+async def worker(queue: asyncio.Queue, session: aiohttp.ClientSession, proxy: str,
+                 processed_ids: set):
     while True:
         row = await queue.get()
         try:
@@ -82,9 +85,15 @@ async def worker(queue: asyncio.Queue, session: aiohttp.ClientSession, proxy: st
                         timeout=15
                     )
                 except asyncio.TimeoutError:
-                    pass  # Skip this domain, move on
-        except Exception:
-            pass
+                    # Row is kept either way — record why the probe columns are empty
+                    append_error(row, "probe:timeout")
+                except asyncio.CancelledError:
+                    append_error(row, "probe:deadline_exceeded")
+                    raise
+            processed_ids.add(id(row))
+        except Exception as e:
+            append_error(row, f"probe:{type(e).__name__}")
+            processed_ids.add(id(row))
         finally:
             queue.task_done()
 
@@ -102,7 +111,8 @@ async def _probe_domain(row: dict, domain: str, session: aiohttp.ClientSession, 
     row["http_redirect_status"] = res_http["redirect_status"]
     row["http_redirect_target"] = res_http["redirect_target"]
 
-async def prober(input_file: str, output_file: str, max_workers: int, proxy: str, limit: int = 0):
+async def prober(input_file: str, output_file: str, max_workers: int, proxy: str,
+                 limit: int = 0, timeout_minutes: int = 30):
     rows = []
     fieldnames = []
     
@@ -127,6 +137,8 @@ async def prober(input_file: str, output_file: str, max_workers: int, proxy: str
     for c in new_cols:
         if c not in fieldnames:
             fieldnames.append(c)
+    if "error" not in fieldnames:
+        fieldnames.append("error")
             
     print(f"[*] Probing {len(rows)} domains with {max_workers} workers...")
     
@@ -138,17 +150,19 @@ async def prober(input_file: str, output_file: str, max_workers: int, proxy: str
         
     # Connector tuning
     connector = aiohttp.TCPConnector(limit=0, ttl_dns_cache=300, force_close=False)
-    
+
     # Global deadline: write partial results instead of hanging in CI
-    global_timeout_secs = 30 * 60  # 30 minutes
+    global_timeout_secs = timeout_minutes * 60
+
+    processed_ids: set = set()
 
     async with aiohttp.ClientSession(connector=connector) as session:
         # Create workers
         workers = []
         for _ in range(max_workers):
-            task = asyncio.create_task(worker(queue, session, proxy))
+            task = asyncio.create_task(worker(queue, session, proxy, processed_ids))
             workers.append(task)
-            
+
         # Wait for queue to process (with hard deadline)
         try:
             async def _drain():
@@ -161,18 +175,42 @@ async def prober(input_file: str, output_file: str, max_workers: int, proxy: str
             await asyncio.wait_for(_drain(), timeout=global_timeout_secs)
         except asyncio.TimeoutError:
             remaining = queue.qsize()
-            print(f"\n[!] Global timeout reached. {remaining} domains skipped. Writing partial results.")
-        
+            print(f"\n[!] Global timeout reached. {remaining} domains not probed; "
+                  f"their rows are kept and annotated.")
+
         # Cancel workers
         for w in workers:
             w.cancel()
-            
+
+    # Rows never picked up (or cancelled mid-probe) are kept, with the reason recorded.
+    for r in rows:
+        if id(r) not in processed_ids:
+            append_error(r, "probe:deadline_exceeded")
+
     print(f"\n[*] Writing results to {output_file}...")
     with open(output_file, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)
-    
+
+    # Reconcile what landed on disk against the input rows.
+    written = set()
+    with open(output_file, "r", newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            written.add(row.get("domain", ""))
+    expected = {r.get("domain", "") for r in rows}
+    if written != expected:
+        missing = sorted(expected - written)
+        print(f"[RECONCILE] FAIL (probe_web): {len(missing)} input domains missing "
+              f"from output. Sample: {missing[:10]}")
+        sys.exit(1)
+    print(f"[RECONCILE] OK (probe_web): {len(rows)} rows out == {len(rows)} rows in")
+
+    n_timeout = sum(1 for r in rows if "probe:timeout" in (r.get("error") or ""))
+    n_deadline = sum(1 for r in rows if "probe:deadline_exceeded" in (r.get("error") or ""))
+    print(f"[SUMMARY] input={len(rows)} output={len(rows)} "
+          f"probed={len(rows) - n_timeout - n_deadline} "
+          f"probe_timeout={n_timeout} deadline_unattempted={n_deadline}")
     print("[*] Done.")
 
 def main():
@@ -182,14 +220,17 @@ def main():
     ap.add_argument("--workers", type=int, default=50, help="Concurrency limit. Default 50 (Reasonable for public scanning).") 
     ap.add_argument("--proxy", help="Proxy URL (e.g. http://localhost:8080)")
     ap.add_argument("--limit", type=int, default=0, help="Max domains to scan (for testing).")
-    
+    ap.add_argument("--timeout-minutes", type=int, default=30,
+                    help="Global time budget in minutes (default 30). Unprobed rows are kept and annotated.")
+
     args = ap.parse_args()
-    
+
     # Windows SelectorPolicy fix for asyncio
     if sys.platform == 'win32':
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        
-    asyncio.run(prober(args.input, args.output, args.workers, args.proxy, args.limit))
+
+    asyncio.run(prober(args.input, args.output, args.workers, args.proxy, args.limit,
+                       args.timeout_minutes))
 
 if __name__ == "__main__":
     main()

--- a/scripts/shared/rowutil.py
+++ b/scripts/shared/rowutil.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""
+shared/rowutil.py
+
+Helpers for annotating pipeline CSV rows in place.
+"""
+
+
+def append_error(row: dict, marker: str) -> None:
+    """Append a stage-tagged marker to row['error'] without duplicating it.
+
+    Later pipeline stages share one ``error`` column with earlier stages, so
+    markers are appended with ';' rather than overwriting, and re-annotation
+    with the same marker is a no-op (stages can touch a row more than once
+    around a deadline).
+    """
+    existing = (row.get("error") or "").strip()
+    if marker in existing:
+        return
+    row["error"] = f"{existing};{marker}" if existing else marker

--- a/tests/test_pipeline_completeness.py
+++ b/tests/test_pipeline_completeness.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Regression tests for the silent domain-drop bug in the shard pipeline.
+
+Incident: dea_domains_probed.csv was missing contiguous alphabetical bands of
+input domains, different bands each run. Root cause: enrich_infrastructure.py's
+--timeout-minutes deadline broke out of the result-collection loop and wrote
+only completed rows, silently dropping the unprocessed tail of each shard.
+
+Contract under test: every input domain produces exactly one output row; rows
+that could not be enriched carry a populated ``error`` column; each stage
+reconciles its output domain set against its input and fails loudly on
+mismatch.
+"""
+
+import asyncio
+import csv
+import os
+import sys
+import time
+from types import SimpleNamespace
+
+import dns.asyncresolver
+import dns.exception
+import dns.resolver
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+import enrich_infrastructure as ei
+import enrich_reputation as rep
+import merge_results
+import probe_web
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_domains_csv(path, domains, extra_cols=None):
+    extra_cols = extra_cols or {}
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["domain"] + list(extra_cols))
+        for d in domains:
+            writer.writerow([d] + [extra_cols[c] for c in extra_cols])
+
+
+def _read_rows(path):
+    with open(path, "r", newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def _fake_answer(rdtype):
+    """Minimal fake dnspython answer objects for each rdtype the code parses."""
+    if rdtype == "NS":
+        return [SimpleNamespace(target="ns1.ok.example.")]
+    if rdtype == "MX":
+        return [SimpleNamespace(preference=10, exchange="mx.ok.example.")]
+    if rdtype == "A":
+        return [SimpleNamespace(to_text=lambda: "203.0.113.7")]
+    if rdtype == "TXT":
+        return [SimpleNamespace(to_text=lambda: '"13335 | 203.0.113.0/24 | US | arin"')]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# enrich_infrastructure: deadline must not drop domains (the incident)
+# ---------------------------------------------------------------------------
+
+class TestDeadlineCompleteness:
+    def test_deadline_truncation_writes_row_for_every_domain(self, tmp_path, monkeypatch):
+        """When the global deadline fires mid-run, unprocessed domains must
+        still be written as rows with a populated error column, not dropped.
+
+        Mirrors the incident: input sorted, a contiguous tail is slow, the
+        deadline cuts processing partway through.
+        """
+        domains = [f"{p}{i:02d}.example" for p in ("aa", "bb", "cc", "dd") for i in range(10)]
+        slow = set(domains[20:])  # contiguous tail, like a shard tail
+
+        inp = tmp_path / "in.csv"
+        out = tmp_path / "out.csv"
+        _write_domains_csv(inp, domains)
+
+        class FakeResolver:
+            def __init__(self, nameservers=None):
+                pass
+
+            async def resolve_ns(self, domain):
+                if domain in slow:
+                    await asyncio.sleep(2.5)
+                return ["ns1.fast.example"]
+
+            async def resolve_a(self, hostname):
+                return ""
+
+            async def resolve_mx(self, domain):
+                return []
+
+        monkeypatch.setattr(ei, "AsyncResolver", FakeResolver)
+        monkeypatch.setattr(ei, "_DEADLINE", time.time() + 1.0)
+
+        asyncio.run(ei.runner(str(inp), str(out), concurrency=5))
+
+        rows = _read_rows(out)
+        out_domains = [r["domain"] for r in rows]
+
+        # The actual deliverable: no input domain may vanish.
+        assert len(out_domains) == len(domains), (
+            f"{len(domains) - len(out_domains)} domains dropped from output"
+        )
+        assert set(out_domains) == set(domains)
+
+        # Unenriched rows must say why.
+        for r in rows:
+            enriched = bool(r["nameservers"])
+            assert enriched or r["error"], f"{r['domain']} has no data and no error"
+
+        deadline_rows = [r for r in rows if r["error"] == "deadline_exceeded"]
+        assert len(deadline_rows) >= 10, "expected the unprocessed tail to be marked"
+
+    def test_reconcile_or_die_fails_loudly_on_mismatch(self, capsys):
+        inputs = {"a.example", "b.example", "c.example", "d.example"}
+        outputs = {"a.example"}
+
+        with pytest.raises(SystemExit) as excinfo:
+            ei.reconcile_or_die(inputs, outputs)
+        assert excinfo.value.code == 1
+
+        printed = capsys.readouterr().out
+        assert "3" in printed  # missing count
+        assert "b.example" in printed  # sample of missing domains
+
+        # Equal sets must not raise.
+        ei.reconcile_or_die(inputs, set(inputs))
+
+
+# ---------------------------------------------------------------------------
+# enrich_infrastructure: transient failures retried then recorded, permanent
+# failures recorded without retry (DNS layer mocked, contiguous slice raises)
+# ---------------------------------------------------------------------------
+
+class TestFailureClassification:
+    def _run_with_dns(self, tmp_path, monkeypatch, domains, side_effect):
+        """Run runner() with the real AsyncResolver but the dnspython layer
+        mocked. side_effect(qname, rdtype) returns answers or raises."""
+        calls = {}
+
+        async def fake_resolve(self_resolver, qname, rdtype, *args, **kwargs):
+            key = (str(qname).rstrip("."), rdtype)
+            calls[key] = calls.get(key, 0) + 1
+            return side_effect(str(qname).rstrip("."), rdtype)
+
+        monkeypatch.setattr(dns.asyncresolver.Resolver, "resolve", fake_resolve)
+        monkeypatch.setattr(ei, "RETRY_BACKOFF_BASE", 0.01, raising=False)
+        monkeypatch.setattr(ei, "_DEADLINE", None)
+
+        inp = tmp_path / "in.csv"
+        out = tmp_path / "out.csv"
+        _write_domains_csv(inp, domains)
+        asyncio.run(ei.runner(str(inp), str(out), concurrency=10))
+        return _read_rows(out), calls
+
+    def test_transient_dns_slice_is_retried_and_recorded(self, tmp_path, monkeypatch):
+        """A contiguous slice of the input times out on every DNS query.
+        Every domain must still appear in the output; the failing slice must
+        carry a transient error after retry exhaustion."""
+        domains = [f"{p}{i:02d}.example" for p in ("fa", "fb", "fc") for i in range(10)]
+        failing = set(domains[10:20])  # the whole 'fb' prefix
+
+        def side_effect(qname, rdtype):
+            if qname in failing:
+                raise dns.exception.Timeout()
+            return _fake_answer(rdtype)
+
+        rows, calls = self._run_with_dns(tmp_path, monkeypatch, domains, side_effect)
+
+        assert {r["domain"] for r in rows} == set(domains)
+        assert len(rows) == len(domains)
+
+        for r in rows:
+            if r["domain"] in failing:
+                assert r["error"].startswith("transient:"), (
+                    f"{r['domain']} should record a transient error, got {r['error']!r}"
+                )
+            else:
+                assert r["error"] == ""
+                assert r["nameservers"] == "ns1.ok.example"
+
+        # Transient failures must be retried with backoff before giving up.
+        assert calls[("fb00.example", "NS")] >= 2, "expected a retry on timeout"
+        assert calls[("fa00.example", "NS")] == 1
+
+    def test_nxdomain_is_permanent_and_not_retried(self, tmp_path, monkeypatch):
+        domains = [f"{p}{i:02d}.example" for p in ("ga", "gb") for i in range(5)]
+        dead = set(domains[5:])  # the whole 'gb' prefix
+
+        def side_effect(qname, rdtype):
+            if qname in dead:
+                raise dns.resolver.NXDOMAIN()
+            return _fake_answer(rdtype)
+
+        rows, calls = self._run_with_dns(tmp_path, monkeypatch, domains, side_effect)
+
+        assert {r["domain"] for r in rows} == set(domains)
+        for r in rows:
+            if r["domain"] in dead:
+                assert r["error"] == "NXDOMAIN"
+            else:
+                assert r["error"] == ""
+
+        assert calls[("gb00.example", "NS")] == 1, "NXDOMAIN must not be retried"
+
+
+# ---------------------------------------------------------------------------
+# merge_results: end-of-run reconciliation against the pipeline input
+# ---------------------------------------------------------------------------
+
+class TestMergeReconciliation:
+    def _write_shard(self, path, domains):
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["domain", "primary_mx", "error"])
+            for d in domains:
+                writer.writerow([d, "", ""])
+
+    def test_missing_domains_fail_the_merge(self, tmp_path, monkeypatch, capsys):
+        self._write_shard(tmp_path / "result_part_0.csv", ["a.example", "b.example"])
+        self._write_shard(tmp_path / "result_part_1.csv", ["c.example", "d.example"])
+        expect = tmp_path / "input.csv"
+        _write_domains_csv(expect, ["a.example", "b.example", "c.example", "d.example", "e.example"])
+
+        out = tmp_path / "merged.csv"
+        monkeypatch.setattr(sys, "argv", [
+            "merge_results.py",
+            "--pattern", str(tmp_path / "result_part_*.csv"),
+            "--output", str(out),
+            "--expect-input", str(expect),
+        ])
+        with pytest.raises(SystemExit) as excinfo:
+            merge_results.main()
+        assert excinfo.value.code == 1
+
+        printed = capsys.readouterr().out
+        assert "e.example" in printed
+        assert "1" in printed
+
+    def test_complete_merge_passes_reconciliation(self, tmp_path, monkeypatch):
+        self._write_shard(tmp_path / "result_part_0.csv", ["a.example", "b.example"])
+        self._write_shard(tmp_path / "result_part_1.csv", ["c.example", "d.example"])
+        expect = tmp_path / "input.csv"
+        _write_domains_csv(expect, ["a.example", "b.example", "c.example", "d.example"])
+
+        out = tmp_path / "merged.csv"
+        monkeypatch.setattr(sys, "argv", [
+            "merge_results.py",
+            "--pattern", str(tmp_path / "result_part_*.csv"),
+            "--output", str(out),
+            "--expect-input", str(expect),
+        ])
+        merge_results.main()  # must not raise
+
+        rows = _read_rows(out)
+        assert {r["domain"] for r in rows} == {"a.example", "b.example", "c.example", "d.example"}
+
+
+# ---------------------------------------------------------------------------
+# enrich_reputation: deadline pass-through must be annotated, never dropped
+# ---------------------------------------------------------------------------
+
+class TestReputationPassThrough:
+    def test_deadline_passthrough_keeps_and_annotates_rows(self, tmp_path, monkeypatch):
+        domains = [f"r{i:02d}.example" for i in range(20)]
+        inp = tmp_path / "in.csv"
+        out = tmp_path / "out.csv"
+        _write_domains_csv(inp, domains, extra_cols={"error": ""})
+
+        monkeypatch.setattr(rep, "_DEADLINE", time.time() - 1)  # already expired
+        monkeypatch.setattr(sys, "argv", [
+            "enrich_reputation.py",
+            "--input", str(inp),
+            "--output", str(out),
+            "--workers", "4",
+        ])
+        rep.main()
+
+        rows = _read_rows(out)
+        assert [r["domain"] for r in rows] == domains, "pass-through must not drop rows"
+        for r in rows:
+            assert "reputation:deadline_exceeded" in r["error"]
+        # The marker must not be applied twice to the same row.
+        assert all(r["error"].count("reputation:deadline_exceeded") == 1 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# probe_web: per-domain timeouts and unattempted rows must be annotated
+# ---------------------------------------------------------------------------
+
+class TestProbeAnnotations:
+    def test_worker_annotates_timeout_and_marks_processed(self, monkeypatch):
+        async def run():
+            row = {"domain": "slow.example", "error": ""}
+            queue = asyncio.Queue()
+            queue.put_nowait(row)
+            processed_ids = set()
+
+            async def fake_wait_for(coro, timeout):
+                coro.close()
+                raise asyncio.TimeoutError()
+
+            monkeypatch.setattr(probe_web.asyncio, "wait_for", fake_wait_for)
+
+            task = asyncio.create_task(
+                probe_web.worker(queue, None, None, processed_ids)
+            )
+            await queue.join()
+            task.cancel()
+
+            assert "probe:timeout" in row["error"]
+            assert id(row) in processed_ids
+
+        asyncio.run(run())


### PR DESCRIPTION
## Problem

`dea_domains_probed.csv` was silently missing thousands of input domains per daily run, confined to contiguous alphabetical prefix bands that changed every run (e.g. Run A lost `em`/`fr`/`ga` bands, Run B lost `fa`/`go`/`gp` — zero overlap).

## Root cause

`enrich_infrastructure.py`''s `--timeout-minutes` deadline broke out of the `as_completed` collection loop and wrote **only completed rows** — every unprocessed/in-flight domain in a timed-out shard was dropped with exit code 0. Sorted input (`merge_lists_v3b.py`) + contiguous sharding (`split_data.py`) turned each dropped shard tail into a contiguous alphabetical band; the ~200-wide concurrency window made band edges ragged. Not exception swallowing: per-domain exceptions always produced rows — only the deadline path lost work.

## Fix — completeness contract

Every input domain now produces exactly one output row at every stage:

- **enrich_infrastructure.py** — past-deadline tasks short-circuit to `error=deadline_exceeded` rows instead of being dropped; transient DNS failures (timeout/SERVFAIL) get a post-pass retry sweep with backoff (out of the hot path, so bulk throughput is unchanged); NXDOMAIN is recorded as permanent, never retried; the run reconciles written output against input (exit 1 + sample on mismatch) and prints `[SUMMARY] input/output/succeeded/permanent/transient/deadline`. New `--nameservers` flag.
- **enrich_reputation.py / probe_web.py** — deadline/timeout pass-throughs annotated in the shared `error` column; reconciliation + summary added; `probe_web` gains `--timeout-minutes` (default 30 = previous hardcoded cap).
- **merge_results.py** — `--expect-input` asserts merged domain set == pipeline input set; unreadable shard files fail the merge loudly.
- **workflow** — merge step reconciles against `data/pipeline_input.csv`, so a lossy run fails the job instead of publishing a holey CSV.

## Verification

- `tests/test_pipeline_completeness.py`: 8 regression tests, incl. a deadline-truncation repro (old code: 34/40 domains dropped; fixed code: 40/40 present with errors annotated) and a mocked-DNS contiguous-slice failure test. Full suite: no new failures.
- Full-scale local acceptance run against `dea_domains.csv` (267,935 domains, 4 shards, CI-equivalent deadlines): **267,935 rows out == 267,935 in**, `[RECONCILE] OK` at all 12 stage runs + merge, `missing=0 extra=0`, and the previously-lost prefixes (`fa go gp fr ga em fu`) 100% present. The deadline fired on ~218k domains during that run — all emitted as annotated rows instead of being dropped, which is exactly the incident condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)