### PR TITLE
fix: Seads scan stops cleanly on wall-clock budget instead of dying at step timeout

### DIFF
--- a/.github/workflows/update_intelligence.yml
+++ b/.github/workflows/update_intelligence.yml
@@ -20,8 +20,8 @@ jobs:
         run: pip install -r requirements.txt
       
       - name: Seads Ad Scan
-        timeout-minutes: 20
-        run: python scripts/run_seads.py
+        timeout-minutes: 30
+        run: python scripts/run_seads.py --budget-seconds 1500
         
       - name: Dnstwist Proactive Hunt
         run: python scripts/generate_permutations.py

--- a/scripts/run_seads.py
+++ b/scripts/run_seads.py
@@ -16,6 +16,7 @@ import json
 import csv
 import platform
 import logging
+import time
 import requests
 import zipfile
 import tarfile
@@ -32,6 +33,7 @@ BINARY_NAME = "seads.exe" if platform.system() == "Windows" else "seads"
 KEYWORDS_FILE = "config/seads_keywords.txt"
 OUTPUT_JSON = "data/seads_raw.json"
 OUTPUT_CSV = "data/discovered_ads.csv"
+PER_KEYWORD_TIMEOUT_SECONDS = 120
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
@@ -150,14 +152,73 @@ def parse_seads_output(current_keyword=""):
     else:
         logging.warning(f"Parsed 0 ads from {len(findings)} raw items. Check JSON keys: {findings[0].keys() if findings else '[]'}")
 
+def scan_keywords(keywords, seads_bin, budget_seconds=None):
+    """Scan each keyword with SEADS, stopping cleanly if the wall-clock budget
+    cannot cover another worst-case keyword. Returns the list of skipped keywords."""
+    start = time.monotonic()
+
+    for i, keyword in enumerate(keywords):
+        if budget_seconds is not None:
+            elapsed = time.monotonic() - start
+            if elapsed + PER_KEYWORD_TIMEOUT_SECONDS > budget_seconds:
+                skipped = keywords[i:]
+                logging.warning(
+                    f"Wall-clock budget exhausted after {i}/{len(keywords)} keywords "
+                    f"({elapsed:.0f}s elapsed of {budget_seconds}s budget). "
+                    f"Skipping {len(skipped)} keywords: {skipped}"
+                )
+                return skipped
+
+        logging.info(f"[{i+1}/{len(keywords)}] Scanning for: '{keyword}'")
+
+        # Create temp config for just this keyword
+        config_data = {
+            "queries": [{"query": keyword}],
+            "concurrency": 1, # Strict Serial to save RAM
+        }
+
+        import yaml
+        temp_config = f"temp_seads_{i}.yaml"
+        with open(temp_config, 'w') as f:
+            yaml.dump(config_data, f)
+
+        cmd = [
+            seads_bin,
+            "-config", temp_config,
+            "-out", OUTPUT_JSON,  # This will be overwritten each time
+            "-screenshot", "",
+            "-noredirect"
+        ]
+
+        try:
+            subprocess.run(cmd, check=False, timeout=PER_KEYWORD_TIMEOUT_SECONDS)
+            # Parse immediately and append
+            parse_seads_output(keyword)
+        except subprocess.TimeoutExpired:
+            logging.error(f"Timeout expired for keyword '{keyword}'. Skipping...")
+        except Exception as e:
+            logging.error(f"Error running seads for '{keyword}': {e}")
+        finally:
+            if os.path.exists(temp_config):
+                os.remove(temp_config)
+            # Clean up json output to avoid duplicates
+            if os.path.exists(OUTPUT_JSON):
+                os.remove(OUTPUT_JSON)
+
+    return []
+
+
 def main():
     seads_bin = install_seads()
-    
+
     # SEADS Refactor: Run iteratively per keyword to prevent OOM/Hang
     # This allows us to kill the process if a specific keyword hangs (like 'secure' on Yahoo)
-    
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--keywords", help="Comma-separated list of keywords to scan (overrides file)")
+    parser.add_argument("--budget-seconds", type=int, default=None,
+                        help="Wall-clock budget; stop starting new keywords when the "
+                             "remaining budget cannot cover one worst-case keyword")
     args = parser.parse_args()
 
     if args.keywords:
@@ -165,7 +226,7 @@ def main():
         logging.info(f"Using manual keywords: {keywords}")
     else:
         all_keywords = load_keywords()
-        # Random sample of 10 to prevent OOM/Timeouts on Github Actions
+        # Random sample of 30 to bound runtime on Github Actions
         # In a real full run, you might want all.
         import random
         keywords = random.sample(all_keywords, min(len(all_keywords), 30))
@@ -179,43 +240,7 @@ def main():
             writer = csv.DictWriter(f, fieldnames=['query', 'ad_domain', 'display_url', 'link', 'engine'])
             writer.writeheader()
 
-    for i, keyword in enumerate(keywords):
-        logging.info(f"[{i+1}/{len(keywords)}] Scanning for: '{keyword}'")
-        
-        # Create temp config for just this keyword
-        config_data = {
-            "queries": [{"query": keyword}],
-            "concurrency": 1, # Strict Serial to save RAM
-        }
-        
-        import yaml
-        temp_config = f"temp_seads_{i}.yaml"
-        with open(temp_config, 'w') as f:
-            yaml.dump(config_data, f)
-            
-        cmd = [
-            seads_bin,
-            "-config", temp_config,
-            "-out", OUTPUT_JSON,  # This will be overwritten each time
-            "-screenshot", "",
-            "-noredirect"
-        ]
-        
-        try:
-            # Enforce 2-minute timeout per keyword
-            subprocess.run(cmd, check=False, timeout=120) 
-            # Parse immediately and append
-            parse_seads_output(keyword)
-        except subprocess.TimeoutExpired:
-            logging.error(f"Timeout expired for keyword '{keyword}'. Skipping...")
-        except Exception as e:
-            logging.error(f"Error running seads for '{keyword}': {e}")
-        finally:
-            if os.path.exists(temp_config):
-                os.remove(temp_config)
-            # Clean up json output to avoid duplicates
-            if os.path.exists(OUTPUT_JSON):
-                os.remove(OUTPUT_JSON)
+    scan_keywords(keywords, seads_bin, budget_seconds=args.budget_seconds)
 
 
 

--- a/tests/test_run_seads_budget.py
+++ b/tests/test_run_seads_budget.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Regression tests for the Seads Ad Scan wall-clock budget (issue #50).
+
+Incident: the Daily Data Update discovery job died at the workflow step's
+``timeout-minutes: 20`` while run_seads.py was on keyword 25/30, skipping every
+later discovery step. Worst-case runtime (30 keywords x 120s subprocess
+timeout) never fit the step budget; slow ad-engine days pushed real runtime
+past it.
+
+Contract under test: scan_keywords() stops starting new keywords once the
+remaining budget cannot cover one worst-case keyword, logs exactly which
+keywords were skipped, and returns cleanly so the workflow step exits 0 with
+partial results.
+"""
+
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+import run_seads
+
+
+class FakeClock:
+    """Monotonic clock advanced manually by the fake subprocess runner."""
+
+    def __init__(self):
+        self.now = 1000.0
+
+    def monotonic(self):
+        return self.now
+
+
+def _install_fakes(monkeypatch, seconds_per_keyword):
+    """Replace run_seads' time and subprocess module references (namespace-local,
+    no global patching). Returns (clock, calls) where calls collects the keyword
+    scanned by each fake subprocess invocation."""
+    clock = FakeClock()
+    calls = []
+
+    def fake_run(cmd, check=False, timeout=None):
+        calls.append(cmd)
+        clock.now += seconds_per_keyword
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(run_seads, "time", SimpleNamespace(monotonic=clock.monotonic))
+    monkeypatch.setattr(
+        run_seads,
+        "subprocess",
+        SimpleNamespace(run=fake_run, TimeoutExpired=subprocess.TimeoutExpired),
+    )
+    return clock, calls
+
+
+def test_stops_cleanly_when_budget_cannot_cover_next_keyword(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    _clock, calls = _install_fakes(monkeypatch, seconds_per_keyword=100)
+    keywords = [f"kw{i}" for i in range(10)]
+
+    # budget 500s, per-keyword worst case 120s: after 4 scans elapsed=400,
+    # 400+120 > 500, so keyword 5 must not start.
+    skipped = run_seads.scan_keywords(keywords, "seads", budget_seconds=500)
+
+    assert len(calls) == 4
+    assert skipped == keywords[4:]
+
+
+def test_logs_skipped_keywords(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    _install_fakes(monkeypatch, seconds_per_keyword=100)
+    keywords = [f"kw{i}" for i in range(10)]
+
+    with caplog.at_level("WARNING"):
+        run_seads.scan_keywords(keywords, "seads", budget_seconds=500)
+
+    log_text = caplog.text
+    assert "4/10" in log_text
+    for kw in keywords[4:]:
+        assert kw in log_text
+
+
+def test_no_budget_scans_all_keywords(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _clock, calls = _install_fakes(monkeypatch, seconds_per_keyword=100)
+    keywords = [f"kw{i}" for i in range(10)]
+
+    skipped = run_seads.scan_keywords(keywords, "seads", budget_seconds=None)
+
+    assert len(calls) == 10
+    assert skipped == []
+
+
+def test_generous_budget_scans_all_keywords(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _clock, calls = _install_fakes(monkeypatch, seconds_per_keyword=10)
+    keywords = [f"kw{i}" for i in range(5)]
+
+    skipped = run_seads.scan_keywords(keywords, "seads", budget_seconds=3600)
+
+    assert len(calls) == 5
+    assert skipped == []
+
+
+def test_main_passes_budget_seconds_to_scan(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("data")
+    captured = {}
+
+    monkeypatch.setattr(run_seads, "install_seads", lambda: "seads")
+
+    def fake_scan(keywords, seads_bin, budget_seconds=None):
+        captured["keywords"] = keywords
+        captured["budget_seconds"] = budget_seconds
+        return []
+
+    monkeypatch.setattr(run_seads, "scan_keywords", fake_scan)
+    monkeypatch.setattr(
+        sys, "argv", ["run_seads.py", "--keywords", "a,b", "--budget-seconds", "300"]
+    )
+
+    run_seads.main()
+
+    assert captured["keywords"] == ["a", "b"]
+    assert captured["budget_seconds"] == 300

--- a/tests/test_run_seads_budget.py
+++ b/tests/test_run_seads_budget.py
@@ -37,8 +37,8 @@ class FakeClock:
 
 def _install_fakes(monkeypatch, seconds_per_keyword):
     """Replace run_seads' time and subprocess module references (namespace-local,
-    no global patching). Returns (clock, calls) where calls collects the keyword
-    scanned by each fake subprocess invocation."""
+    no global patching). Returns (clock, calls) where calls collects the full
+    command list of each fake subprocess invocation."""
     clock = FakeClock()
     calls = []
 
@@ -56,7 +56,7 @@ def _install_fakes(monkeypatch, seconds_per_keyword):
     return clock, calls
 
 
-def test_stops_cleanly_when_budget_cannot_cover_next_keyword(monkeypatch, tmp_path, caplog):
+def test_stops_cleanly_when_budget_cannot_cover_next_keyword(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     _clock, calls = _install_fakes(monkeypatch, seconds_per_keyword=100)
     keywords = [f"kw{i}" for i in range(10)]
@@ -81,6 +81,19 @@ def test_logs_skipped_keywords(monkeypatch, tmp_path, caplog):
     assert "4/10" in log_text
     for kw in keywords[4:]:
         assert kw in log_text
+
+
+def test_budget_smaller_than_one_keyword_skips_everything(monkeypatch, tmp_path, caplog):
+    monkeypatch.chdir(tmp_path)
+    _clock, calls = _install_fakes(monkeypatch, seconds_per_keyword=100)
+    keywords = [f"kw{i}" for i in range(3)]
+
+    with caplog.at_level("WARNING"):
+        skipped = run_seads.scan_keywords(keywords, "seads", budget_seconds=60)
+
+    assert calls == []
+    assert skipped == keywords
+    assert "0/3" in caplog.text
 
 
 def test_no_budget_scans_all_keywords(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #50

## Summary
- **Incident:** scheduled Daily Data Update run 31577186825 (2026-08-12) failed — the Seads Ad Scan step hit `timeout-minutes: 20` at keyword 25/30, hard-failing the discovery job and skipping Dnstwist Hunt, Campaign Hunt, CT Discovery, MX Pivot, and Upload Discovery Intel.
- **Root cause:** 30 sampled keywords × 7 engines serially with a 120s per-keyword subprocess timeout has a worst case of 60 min against a 20-min step budget; recent good runs took 12–16 min, so slow ad-engine days (Yahoo was ~26s/lookup) bust the limit. The 30-keyword sample and 20-min timeout shipped together in 7f7198585.
- **Fix:** `run_seads.py` gains `--budget-seconds`; `scan_keywords()` stops starting new keywords once the remaining budget cannot cover one worst-case keyword (120s), logs a WARNING naming exactly which keywords were skipped (same visibility principle as the PR #49 reconciliation guard), and exits 0 with partial results. Partial coverage is already the design — keywords are a random sample.
- **Workflow:** step now runs with `--budget-seconds 1500` (self-limits to ~25 min) and `timeout-minutes: 30` as a backstop that should never fire. Without the flag, behavior is unchanged.

## Test Plan
- [x] TDD: 6 tests in `tests/test_run_seads_budget.py` written first and observed failing (`AttributeError: no attribute 'scan_keywords'`), then passing — budget stop, skipped-keyword logging, sub-worst-case budget skips everything, no-budget unchanged, generous budget scans all, `main()` wiring. Fakes are namespace-local (no `sys.modules` pollution).
- [x] `python -m pytest tests/test_run_seads_budget.py -q` → 6 passed
- [x] `py_compile` on the script; workflow YAML parses
- [ ] After merge: confirm next scheduled run's Seads step finishes under 25 min and, if the budget fires, the skipped-keyword WARNING appears

## Deferred (from code review — polish, non-blocking)
- Budget clock starts at scan start, not `main()` start; `install_seads()` time eats backstop headroom (~1–3 min worst case, still safe).
- No validation guard for `--budget-seconds` typos below 120s (a full skip is loudly logged, so visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCRafs47Mh32b3SLKbXUWZ