### PR TITLE
fix: stop visual fingerprinting leaking pages and stalling the batch

### DIFF
--- a/scripts/visual_fingerprint.py
+++ b/scripts/visual_fingerprint.py
@@ -83,6 +83,10 @@ def get_targets(limit: int) -> List[str]:
     # Return top N
     return [c[0] for c in candidates[:limit]]
 
+# Hard ceiling per domain. Without it a single unresponsive site can stall
+# the batch and blow the CI step's wall-clock budget (see run 32459415652).
+PER_DOMAIN_TIMEOUT = 45
+
 async def capture_and_hash(domains: List[str], concurrency: int) -> List[dict]:
     results = []
     
@@ -92,47 +96,62 @@ async def capture_and_hash(domains: List[str], concurrency: int) -> List[dict]:
         
         sem = asyncio.Semaphore(concurrency)
 
-        async def process(domain):
+        async def _capture_one(domain):
             url = f"http://{domain}" # Try HTTP first
-            async with sem:
-                page = await context.new_page()
+            page = await context.new_page()
+            try:
+                logging.info(f"Screenshotting {domain}...")
                 try:
-                    logging.info(f"Screenshotting {domain}...")
+                    await page.goto(url, timeout=10000, wait_until="domcontentloaded")
+                    await asyncio.sleep(1) # Render
+                except PlaywrightError as e:
+                    logging.debug("HTTP failed for %s, trying HTTPS: %s", domain, e)
+                    # Try HTTPS
                     try:
+                        url = f"https://{domain}"
                         await page.goto(url, timeout=10000, wait_until="domcontentloaded")
-                        await asyncio.sleep(1) # Render
+                        await asyncio.sleep(1)
                     except PlaywrightError as e:
-                        logging.debug("HTTP failed for %s, trying HTTPS: %s", domain, e)
-                        # Try HTTPS
-                        try:
-                            url = f"https://{domain}"
-                            await page.goto(url, timeout=10000, wait_until="domcontentloaded")
-                            await asyncio.sleep(1)
-                        except PlaywrightError as e:
-                            logging.warning("Both HTTP and HTTPS failed for %s: %s", domain, e)
-                            return None
+                        logging.warning("Both HTTP and HTTPS failed for %s: %s", domain, e)
+                        return None
 
-                    # Screenshot (JPEG for smaller size)
-                    # We capture as PNG in memory for hashing (better precision), but save as JPEG for web display
-                    png_bytes = await page.screenshot(full_page=False)
-                    img = Image.open(BytesIO(png_bytes))
+                # Screenshot (JPEG for smaller size)
+                # We capture as PNG in memory for hashing (better precision), but save as JPEG for web display
+                png_bytes = await page.screenshot(full_page=False)
+                img = Image.open(BytesIO(png_bytes))
 
-                    # Save to disk for dashboard (Convert to JPEG)
-                    screenshot_path = f"data/screenshots/{domain}.jpg"
-                    os.makedirs("data/screenshots", exist_ok=True)
-                    
-                    rgb_im = img.convert('RGB')
-                    rgb_im.save(screenshot_path, format='JPEG', quality=70, optimize=True)
-                    
-                    # Hash
-                    phash = str(imagehash.phash(img))
-                    
-                    await page.close()
-                    return {"domain": domain, "url": url, "phash": phash}
-                    
-                except Exception as e:
-                    logging.error(f"Error {domain}: {e}")
-                    await page.close()
+                # Save to disk for dashboard (Convert to JPEG)
+                screenshot_path = f"data/screenshots/{domain}.jpg"
+                os.makedirs("data/screenshots", exist_ok=True)
+                
+                rgb_im = img.convert('RGB')
+                rgb_im.save(screenshot_path, format='JPEG', quality=70, optimize=True)
+                
+                # Hash
+                phash = str(imagehash.phash(img))
+                
+                return {"domain": domain, "url": url, "phash": phash}
+                
+            except Exception as e:
+                logging.error(f"Error {domain}: {e}")
+                return None
+            finally:
+                # Always close: a leaked page per unreachable domain
+                # accumulates and degrades the browser over a long scan.
+                await page.close()
+
+
+        async def process(domain):
+            async with sem:
+                try:
+                    return await asyncio.wait_for(
+                        _capture_one(domain), PER_DOMAIN_TIMEOUT
+                    )
+                except asyncio.TimeoutError:
+                    # One unresponsive domain must not consume the step's budget.
+                    logging.warning(
+                        "Timed out on %s after %ss", domain, PER_DOMAIN_TIMEOUT
+                    )
                     return None
 
         tasks = [process(d) for d in domains]

--- a/tests/test_visual_fingerprint.py
+++ b/tests/test_visual_fingerprint.py
@@ -1,0 +1,186 @@
+"""Tests for visual_fingerprint screenshot capture."""
+
+import asyncio
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import visual_fingerprint as vf
+from playwright.async_api import Error as PlaywrightError
+
+
+class FakePage:
+    """Records whether it was closed, so leaks are detectable."""
+
+    def __init__(self, registry, goto_error=True):
+        self.closed = False
+        self.goto_error = goto_error
+        registry.append(self)
+
+    async def goto(self, url, timeout=None, wait_until=None):
+        if self.goto_error:
+            raise PlaywrightError("net::ERR_CONNECTION_REFUSED")
+
+    async def screenshot(self, full_page=False):
+        raise AssertionError("screenshot should not run after goto failure")
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeContext:
+    def __init__(self, registry):
+        self._registry = registry
+
+    async def new_page(self):
+        return FakePage(self._registry)
+
+
+class FakeBrowser:
+    def __init__(self, registry):
+        self._registry = registry
+
+    async def new_context(self, **kwargs):
+        return FakeContext(self._registry)
+
+    async def close(self):
+        pass
+
+
+class FakeChromium:
+    def __init__(self, registry):
+        self._registry = registry
+
+    async def launch(self, headless=True):
+        return FakeBrowser(self._registry)
+
+
+class FakePlaywright:
+    def __init__(self, registry):
+        self.chromium = FakeChromium(registry)
+
+
+class FakePlaywrightCM:
+    def __init__(self, registry):
+        self._registry = registry
+
+    async def __aenter__(self):
+        return FakePlaywright(self._registry)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class TestPageLifecycle:
+    """Pages must never leak, regardless of which path a domain takes."""
+
+    def test_page_closed_when_all_protocols_fail(self):
+        """Unreachable over both HTTP and HTTPS must still close the page.
+
+        Leaked pages accumulate in the browser across a large scan and
+        degrade it until the step stalls (see run 32459415652).
+        """
+        registry = []
+        with patch.object(vf, "async_playwright", lambda: FakePlaywrightCM(registry)):
+            results = asyncio.run(vf.capture_and_hash(["unreachable.example"], 1))
+
+        assert results == []
+        assert len(registry) == 1, "expected exactly one page to be created"
+        assert registry[0].closed, "page was not closed on the failure path (leak)"
+
+    def test_no_pages_leak_across_many_failures(self):
+        """Every page in a batch of failing domains must be closed."""
+        registry = []
+        domains = [f"bad{i}.example" for i in range(25)]
+        with patch.object(vf, "async_playwright", lambda: FakePlaywrightCM(registry)):
+            results = asyncio.run(vf.capture_and_hash(domains, 5))
+
+        assert results == []
+        assert len(registry) == 25
+        leaked = [p for p in registry if not p.closed]
+        assert not leaked, f"{len(leaked)} of {len(registry)} pages leaked"
+
+
+class HangingPage:
+    """Simulates a domain that accepts the connection then never responds."""
+
+    def __init__(self, registry):
+        self.closed = False
+        registry.append(self)
+
+    async def goto(self, url, timeout=None, wait_until=None):
+        await asyncio.sleep(3600)
+
+    async def screenshot(self, full_page=False):
+        await asyncio.sleep(3600)
+
+    async def close(self):
+        self.closed = True
+
+
+class HangingContext:
+    def __init__(self, registry):
+        self._registry = registry
+
+    async def new_page(self):
+        return HangingPage(self._registry)
+
+
+class HangingBrowser:
+    def __init__(self, registry):
+        self._registry = registry
+
+    async def new_context(self, **kwargs):
+        return HangingContext(self._registry)
+
+    async def close(self):
+        pass
+
+
+class HangingChromium:
+    def __init__(self, registry):
+        self._registry = registry
+
+    async def launch(self, headless=True):
+        return HangingBrowser(self._registry)
+
+
+class HangingPlaywright:
+    def __init__(self, registry):
+        self.chromium = HangingChromium(registry)
+
+
+class HangingPlaywrightCM:
+    def __init__(self, registry):
+        self._registry = registry
+
+    async def __aenter__(self):
+        return HangingPlaywright(self._registry)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class TestStallContainment:
+    """No single domain may stall the whole batch."""
+
+    def test_hanging_domain_is_abandoned(self):
+        """A domain that never responds is dropped, not waited on forever.
+
+        Run 32459415652 stalled 18 minutes on one domain and blew the
+        step's 30-minute budget with half the batch unprocessed.
+        """
+        registry = []
+
+        async def run():
+            with patch.object(vf, "async_playwright", lambda: HangingPlaywrightCM(registry)):
+                with patch.object(vf, "PER_DOMAIN_TIMEOUT", 0.05):
+                    return await asyncio.wait_for(
+                        vf.capture_and_hash(["hangs.example"], 1), timeout=5
+                    )
+
+        results = asyncio.run(run())
+        assert results == []
+        assert registry and registry[0].closed, "hung page was not closed"


### PR DESCRIPTION
## Context

[#53](https://github.com/elchacal801/domain_intel/pull/53) stopped `Visual Fingerprinting (Optional)` from discarding the run's commit when it times out. This PR addresses **why it times out**.

In run [32459415652](https://github.com/elchacal801/domain_intel/actions/runs/32459415652):

```
11:12:06  INFO - Screenshotting healthharborhub.com...
11:30:13  ##[error] timed out after 30 minutes
```

18 minutes on one domain, with roughly half of `--limit 1000` unprocessed.

## Root cause: page leak

`capture_and_hash()` closed the page on the success path (line 130) and in the generic `except` (line 135) — but the **both-protocols-failed branch returned `None` without closing** (line 113):

```python
except PlaywrightError as e:
    logging.warning("Both HTTP and HTTPS failed for %s: %s", domain, e)
    return None          # <-- page never closed
```

Every unreachable domain leaked an open page into the shared browser context. Across a scan of 1000 mostly-suspicious domains — where unreachable is the common case — those accumulate until the browser degrades and stops responding. That matches the observed progressive slowdown and halfway-point hang.

Fixed by moving the close into a `finally`, so it runs on every path.

## Defence in depth: stall containment

`page.goto()` was bounded at 10s, but nothing bounded the rest of the per-domain work — `screenshot()`, the PIL convert/save, `phash()` — or a browser that had already stopped responding.

`PER_DOMAIN_TIMEOUT` (45s) now wraps the whole per-domain capture in `asyncio.wait_for`. The semaphore is acquired **outside** the timeout, so queued domains don't burn their budget waiting for a concurrency slot — only real capture work is timed.

## Tests

This module had **no tests**. Added three, each written failing first against the current code:

| test | asserts |
|---|---|
| `test_page_closed_when_all_protocols_fail` | unreachable domain still closes its page |
| `test_no_pages_leak_across_many_failures` | no leaks across 25 failing domains |
| `test_hanging_domain_is_abandoned` | a never-responding domain is dropped, not waited on |

The first two fail on `main` with the leak; the third fails with `AttributeError: no attribute 'PER_DOMAIN_TIMEOUT'`.

```
123 passed   (3 new + existing vpn_ip_intel and mullvad_exit_probe suites)
```

## Note

`continue-on-error` from #53 stays valuable regardless — it covers whatever *else* might stall a step. This PR just means it should stop firing for this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
