### PR TITLE
chore(ci): move workflows from Python 3.10 to 3.11

### DIFF
--- a/.github/workflows/drip_whois.yml
+++ b/.github/workflows/drip_whois.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/update_intelligence.yml
+++ b/.github/workflows/update_intelligence.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
         run: pip install -r requirements.txt
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |
@@ -129,7 +129,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Why

Prerequisite for #38 (`pandas >=3.0.2`). **pandas 3.x requires Python `>=3.11`**, so with the workflows pinned to 3.10 that requirement is unsatisfiable — `pip install -r requirements.txt` fails and every job dies at *Install dependencies*.

## Compatibility check

Audited every entry in `requirements.txt`. **None declares an upper bound excluding 3.11:**

| package | constraint |
|---|---|
| litellm (pinned `<=1.83.7`) | `<4.0,>=3.9` |
| python-Levenshtein 0.27.4 | `>=3.10` |
| playwright 1.62.0 | `>=3.10` |
| pytest-asyncio 1.4.0 | `>=3.10` |
| python-dotenv 1.2.3 | `>=3.10` |
| pyyaml 6.0.3 | `>=3.8` |
| imagehash / dnstwist / shodan | unset |

Floors already on `main` (`dnspython>=2.6.1`, `tqdm>=4.67.3`, `aiohttp>=3.13.5`, `Pillow>=12.2.0`, `stix2>=3.0.2`) are all satisfiable on 3.11.

## Scope

- `update_intelligence.yml` — 4 occurrences (`discovery`, `setup`, `process_shard`, `finalize`)
- `drip_whois.yml` — 1 occurrence

`drip_whois.yml` installs no dependencies (stdlib only), so it carries no resolver risk either way. Bumped for consistency — leaving the two workflows on different interpreters invites confusion later.

## Risk

This changes the interpreter for **every job in the pipeline**, so it deserves a watched run. Merge order matters: this first, then #38. Reversing that order breaks the pipeline in the gap.

Worth noting the recent major action bumps (checkout v7 #45, setup-node v7 #48) also haven't been exercised by a run yet — if the next run fails, those are candidates alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
