### PR TITLE
chore: drop unused pandas dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pyyaml
 dnstwist
 pytest
 pytest-asyncio
-pandas>=3.0.2
 python-Levenshtein
 shodan
 stix2>=3.0.2


### PR DESCRIPTION
## Why

**Nothing in this repository imports pandas.** Outside of historical CI logs, the only two occurrences are the `requirements.txt` line itself and a comment in `drip_whois.yml`:

```yaml
# If we needed requests/pandas etc we would install them here
```

Verified across `*.py`, `*.ipynb`, `*.toml`, `*.cfg`, `*.yml`, `*.yaml` — no import, no `pd.` usage.

## Cost of keeping it

It was a *direct* requirement, so every job in every run installed it — a 12.8 MB wheel plus `pytz` and `tzdata` transitively, across 13 jobs per run.

It also generated maintenance: Dependabot kept raising bumps, most recently #38, whose `pandas>=3.0.2` floor requires Python `>=3.11`. That's what made the interpreter move in #55 a prerequisite — for a package nothing uses.

## What this does not change

**The Python 3.11 bump stays.** It's validated end-to-end by run [32585535635](https://github.com/elchacal801/domain_intel/actions/runs/32585535635) and every remaining dependency supports it. Reverting to 3.10 would add risk for no gain.

## Verification

- [x] No pandas import anywhere in the repo
- [x] Remaining 17 requirements all satisfiable on Python 3.11
- [x] Exactly one line removed

Next scheduled run at 07:00 UTC will exercise the install without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
