### PR TITLE
fix(tests): repair suite and add the CI gate that would have caught it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+# Deliberately separate from "Daily Data Update": that workflow is a ~4 hour
+# scheduled data pipeline, while this must run in minutes on every push so a
+# broken change is caught before it is merged.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # A newer push to the same branch supersedes an in-flight run.
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run test suite
+        run: pytest tests/ -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest configuration for the domain_intel test suite.
+
+Puts ``scripts/`` on ``sys.path`` once, for every test module.
+
+36 of 40 test modules previously did this themselves. The four that did not
+could only be collected when some *other* module had already run and set the
+path as a side effect -- ``pytest tests/test_shared.py`` on its own failed with
+``ModuleNotFoundError: No module named 'shared'``. Doing it here removes that
+whole class of ordering dependency; the per-module inserts that remain are now
+redundant but harmless.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))

--- a/tests/test_classify_rules.py
+++ b/tests/test_classify_rules.py
@@ -14,14 +14,26 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
 # test suite can run without API keys or optional dependencies.
 from unittest.mock import MagicMock, patch
 
-# Patch shared modules *before* importing ai_classify_web so module-level code
-# doesn't blow up when OPENAI_API_KEY is absent.
-sys.modules.setdefault("shared.llm_client", MagicMock())
-sys.modules.setdefault("shared.flame_client", MagicMock())
-sys.modules.setdefault("dotenv", MagicMock())
+# Stub heavy/optional imports ONLY while importing the script under test.
+# These modules have import-time side effects (LLMClient instantiation,
+# load_dotenv) that need no API keys here. The previous sys.modules state is
+# restored immediately afterwards -- leaving the stubs in place leaks them into
+# every later test module, which is what caused 66 spurious failures when the
+# suite ran in alphabetical order.
+_stubbed = ("shared.llm_client", "shared.flame_client", "dotenv")
+_saved = {n: sys.modules.get(n) for n in _stubbed}
+for _n in _stubbed:
+    sys.modules.setdefault(_n, MagicMock())
 
-import ai_classify_web  # noqa: E402
-from ai_classify_web import classify_rules  # noqa: E402
+try:
+    import ai_classify_web  # noqa: E402
+    from ai_classify_web import classify_rules  # noqa: E402
+finally:
+    for _n, _prev in _saved.items():
+        if _prev is None:
+            sys.modules.pop(_n, None)
+        else:
+            sys.modules[_n] = _prev
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_delta_mode.py
+++ b/tests/test_delta_mode.py
@@ -20,12 +20,26 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
 # Mock heavy imports before loading script modules
 from unittest.mock import MagicMock
 
-sys.modules.setdefault("shared.llm_client", MagicMock())
-sys.modules.setdefault("shared.flame_client", MagicMock())
-sys.modules.setdefault("dotenv", MagicMock())
+# Stub heavy/optional imports ONLY while importing the script under test.
+# These modules have import-time side effects (LLMClient instantiation,
+# load_dotenv) that need no API keys here. The previous sys.modules state is
+# restored immediately afterwards -- leaving the stubs in place leaks them into
+# every later test module, which is what caused 66 spurious failures when the
+# suite ran in alphabetical order.
+_stubbed = ("shared.llm_client", "shared.flame_client", "dotenv")
+_saved = {n: sys.modules.get(n) for n in _stubbed}
+for _n in _stubbed:
+    sys.modules.setdefault(_n, MagicMock())
 
-import ai_classify_web  # noqa: E402
-import ai_typosquat  # noqa: E402
+try:
+    import ai_classify_web  # noqa: E402
+    import ai_typosquat  # noqa: E402
+finally:
+    for _n, _prev in _saved.items():
+        if _prev is None:
+            sys.modules.pop(_n, None)
+        else:
+            sys.modules[_n] = _prev
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rdap_parsing.py
+++ b/tests/test_rdap_parsing.py
@@ -281,8 +281,15 @@ class TestExtractCreationDate:
         assert _extract_creation_date(data) == ("", "")
 
     def test_age_calculation(self):
-        """Verify age_days is roughly correct."""
-        yesterday = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%Y-%m-%dT00:00:00Z")
+        """Verify age_days is roughly correct.
+
+        The input must be built from UTC, not local time: _extract_creation_date
+        measures age against datetime.now(timezone.utc), so constructing
+        "yesterday" from a local clock behind UTC yields an age of 2 late in the
+        local day.
+        """
+        utc_now = datetime.datetime.now(datetime.timezone.utc)
+        yesterday = (utc_now - datetime.timedelta(days=1)).strftime("%Y-%m-%dT00:00:00Z")
         data = {"events": [{"eventAction": "registration", "eventDate": yesterday}]}
         creation, age = _extract_creation_date(data)
         assert int(age) == 1

--- a/tests/test_suite_hygiene.py
+++ b/tests/test_suite_hygiene.py
@@ -1,0 +1,73 @@
+"""Guards against test-suite defects that hide real failures.
+
+These are meta-tests: they assert properties of the suite itself rather than of
+production code. Both encode faults that actually occurred and cost real time.
+"""
+
+import glob
+import os
+import re
+
+TESTS_DIR = os.path.dirname(__file__)
+
+
+def _test_modules():
+    return sorted(glob.glob(os.path.join(TESTS_DIR, "test_*.py")))
+
+
+class TestNoSysModulesLeakage:
+    """A test module must not permanently stub entries in sys.modules.
+
+    Three modules used to install MagicMocks at import time with no teardown:
+
+        sys.modules.setdefault("shared.llm_client", MagicMock())
+
+    Because pytest collects alphabetically, every module importing those names
+    later received a MagicMock instead of the real thing. That produced 66
+    spurious failures in a full run while each file passed on its own -- the
+    kind of noise that trains people to ignore a red suite.
+
+    Stubbing is still allowed; it must simply be undone. Either restore the
+    previous sys.modules state after the guarded import, or use
+    unittest.mock.patch.dict, which restores on exit.
+    """
+
+    STUB_PATTERN = re.compile(r"sys\.modules\s*(?:\.setdefault\s*\(|\[)")
+
+    def test_stubs_are_restored(self):
+        offenders = []
+        for path in _test_modules():
+            src = open(path, encoding="utf-8", errors="ignore").read()
+            if not self.STUB_PATTERN.search(src):
+                continue
+            restores = "patch.dict" in src or ("_saved" in src and "finally" in src)
+            if not restores:
+                offenders.append(os.path.basename(path))
+
+        assert not offenders, (
+            "these test modules stub sys.modules without restoring it, which "
+            f"leaks into every later module: {offenders}"
+        )
+
+
+class TestModulesAreSelfContained:
+    """Every test module must be importable on its own.
+
+    tests/conftest.py puts scripts/ on sys.path for the whole suite. This test
+    fails if a module reaches for something conftest does not provide, which
+    would once again make collection depend on run order.
+    """
+
+    def test_every_module_declares_its_imports(self):
+        missing = []
+        for path in _test_modules():
+            src = open(path, encoding="utf-8", errors="ignore").read()
+            # A module importing from scripts/ needs either conftest's path
+            # setup (always present now) or its own -- what it must never do is
+            # rely on another *test* module having imported something first.
+            if re.search(r"^from tests\.", src, re.M):
+                missing.append(os.path.basename(path))
+
+        assert not missing, (
+            f"test modules importing from sibling test modules: {missing}"
+        )

--- a/tests/test_typosquat_scoring.py
+++ b/tests/test_typosquat_scoring.py
@@ -12,15 +12,30 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
 # Patch heavy imports before loading the module (no API key needed for tests)
 from unittest.mock import MagicMock
 
-sys.modules.setdefault("shared.llm_client", MagicMock())
-sys.modules.setdefault("dotenv", MagicMock())
+# Stub heavy/optional imports ONLY while importing the script under test.
+# These modules have import-time side effects (LLMClient instantiation,
+# load_dotenv) that need no API keys here. The previous sys.modules state is
+# restored immediately afterwards -- leaving the stubs in place leaks them into
+# every later test module, which is what caused 66 spurious failures when the
+# suite ran in alphabetical order.
+_stubbed = ("shared.llm_client", "dotenv")
+_saved = {n: sys.modules.get(n) for n in _stubbed}
+for _n in _stubbed:
+    sys.modules.setdefault(_n, MagicMock())
 
-from ai_typosquat import (  # noqa: E402
-    score_typosquat,
-    _strip_domain,
-    _levenshtein,
-    _apply_homoglyphs,
-)
+try:
+    from ai_typosquat import (  # noqa: E402
+        score_typosquat,
+        _strip_domain,
+        _levenshtein,
+        _apply_homoglyphs,
+    )
+finally:
+    for _n, _prev in _saved.items():
+        if _prev is None:
+            sys.modules.pop(_n, None)
+        else:
+            sys.modules[_n] = _prev
 
 # Default target list used for most tests
 TARGETS = ["Google", "Microsoft", "PayPal", "Chase", "Netflix", "Apple"]


### PR DESCRIPTION
Implements **Phase 1 and Phase 2** of the remediation plan.

## The situation

The suite reported **67 failures** and nothing noticed, because **no workflow has ever run it** — `grep -rn "pytest" .github/workflows/` returned nothing across 756 tests in 41 files.

```
before   67 failed, 689 passed     test_shared.py uncollectable on its own
after   758 passed                 all 41 files pass individually
```

## Three defects

**1 · Cross-test mock leakage — 66 of the 67**

`test_classify_rules`, `test_delta_mode` and `test_typosquat_scoring` installed MagicMocks at import time and never removed them:

```python
sys.modules.setdefault("shared.llm_client", MagicMock())
```

pytest collects alphabetically, so everything later importing those names got a MagicMock instead of the real module — 32 + 17 + 11 + 6 = 66 failures in a full run, while each file passed alone.

The stubs are genuinely necessary: those scripts do `LLMClient` instantiation and `load_dotenv` at import time. That also means they **cannot** move into a fixture — fixtures run after collection, and the offending import is module-level. So the fix captures the prior `sys.modules` state, stubs only for the guarded import, and restores in a `finally`.

**2 · Order-dependent collection**

`pytest tests/test_shared.py` alone failed with `ModuleNotFoundError: No module named 'shared'` — it depended on another module having already put `scripts/` on `sys.path`. Four of 40 files had no path setup.

Added `tests/conftest.py` to do it once. The 36 per-module inserts are now redundant but harmless, so they're left alone.

**3 · Timezone-dependent age assertion**

`test_age_calculation` built "yesterday" from a **local** clock, while `_extract_creation_date` measures against `datetime.now(timezone.utc)`. Late in the local day, with local behind UTC, they disagree by a day:

```
local now   2026-08-22 23:25        test input  2026-08-21T00:00:00Z
utc now     2026-08-23 05:25        delta       2 days 5h  ->  .days = 2
```

The production code is correct — RDAP event dates are UTC — so the test now builds its input from UTC too. This was a real latent defect, not flakiness: it fails deterministically in that window.

## The gate

`.github/workflows/tests.yml` — pytest on push and pull_request, Python 3.11, actions pinned by SHA to match `update_intelligence.yml`, 15-minute timeout, concurrency cancellation. Kept separate from the pipeline workflow, which is a ~4 hour scheduled job.

**This PR verifies the gate on itself** — the workflow runs against this branch, so the check appearing green here is the demonstration that it works.

## Regression guard

`tests/test_suite_hygiene.py` fails if any test module stubs `sys.modules` without restoring it — the precise regression behind 66 of these failures. Stubbing stays allowed; leaving it installed does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
