### PR TITLE
feat: detect IP-KVM and remote-management exposure (FP-0011)

### DIFF
--- a/.github/workflows/update_intelligence.yml
+++ b/.github/workflows/update_intelligence.yml
@@ -272,6 +272,20 @@ jobs:
           "
           python scripts/enrich_spf.py -i /tmp/actor_mx_domains.txt -o data/spf_enrichment.csv -c 200
 
+      - name: RMM / IP-KVM Exposure Enrichment
+        timeout-minutes: 15
+        continue-on-error: true
+        env:
+          SHODAN_API_KEY: ${{ secrets.SHODAN_API_KEY }}
+        run: |
+          # Must precede Infrastructure Fingerprinting: FP-0011 matches the
+          # kvm_detected / rmm_detected columns this step writes, so running it
+          # afterwards would defer every match to the following day's run.
+          if [ -n "$SHODAN_API_KEY" ]; then
+            python scripts/enrich_rmm_exposure.py               --ip-list data/known_campaign_ips.txt               --asn-seed data/kadnap_operator_asns.csv               --output data/rmm_exposure.csv               --annotate data/dea_domains_probed.csv               --budget 300
+          fi
+          cp data/rmm_exposure.csv docs/data/ || true
+
       - name: Infrastructure Fingerprinting
         run: python scripts/match_fingerprints.py
 

--- a/config/fingerprints/FP-0011-remote-access-exposure.yaml
+++ b/config/fingerprints/FP-0011-remote-access-exposure.yaml
@@ -1,0 +1,125 @@
+id: "FP-0011"
+name: "IP-KVM / Remote-Management Exposure"
+description: >
+  Infrastructure exposing IP-KVM hardware or remote-management (RMM) services
+  to the public internet. 2026 reporting on DPRK IT-worker operations describes
+  laptop farms built on IP-KVM devices -- PiKVM, TinyPilot, JetKVM -- with RMM
+  tooling (AnyDesk, TeamViewer, RustDesk, Chrome Remote Desktop, GoTo/LogMeIn)
+  as the fallback layer where KVM hardware is unavailable. Those connections are
+  reported to originate predominantly from Astrill VPN addresses, a population
+  this pipeline already resolves.
+
+  MITRE ATT&CK covers the technique as T1219.003 (Remote Access Hardware);
+  detection strategy DET0159 targets TinyPilot and PiKVM specifically, but is
+  host-based (USB enumeration, EDID announcements, mount paths) and therefore
+  unavailable to an external pipeline. This fingerprint is the complementary
+  network-side view.
+
+  Populated by scripts/enrich_rmm_exposure.py. Signatures (HTTP titles and
+  favicon hashes) come from runZero, "Out-of-Band, Part 1: the new gen of IP
+  KVMs & how to find them"; ports are vendor defaults.
+
+  SCOPING NOTE: an IP-KVM on the public internet is unusual and worth a look;
+  RDP and VNC are ubiquitous and are scored far lower on purpose. A hit inside
+  a large shared-hosting ASN is a lead, not an attribution -- the ASN's other
+  customers are unrelated.
+version: 1
+
+indicators:
+  # Either class of exposure qualifies the row for scoring; neither is required
+  # on its own, so the fingerprint does not demand both.
+  - field: kvm_detected
+    match_type: exact
+    value: "yes"
+    required: false
+  - field: rmm_detected
+    match_type: exact
+    value: "yes"
+    required: false
+
+confidence_base: 40
+
+confidence_modifiers:
+  # --- IP-KVM hardware: rare on the public internet, high signal ---
+  - field: kvm_products
+    match_type: contains
+    value: "PiKVM"
+    delta: 30
+  - field: kvm_products
+    match_type: contains
+    value: "TinyPilot"
+    delta: 30
+  - field: kvm_products
+    match_type: contains
+    value: "JetKVM"
+    delta: 30
+  - field: kvm_products
+    match_type: contains
+    value: "NanoKVM"
+    delta: 30
+  - field: kvm_products
+    match_type: contains
+    value: "GLKVM"
+    delta: 30
+  - field: kvm_products
+    match_type: contains
+    value: "BliKVM"
+    delta: 30
+  # Guacamole is a legitimate enterprise gateway as well as a farm component,
+  # so it scores below dedicated KVM hardware.
+  - field: kvm_products
+    match_type: contains
+    value: "Apache Guacamole"
+    delta: 15
+
+  # --- RMM: named in DPRK reporting, but also ordinary IT tooling ---
+  - field: rmm_products
+    match_type: contains
+    value: "RustDesk"
+    delta: 20
+  - field: rmm_products
+    match_type: contains
+    value: "AnyDesk"
+    delta: 20
+  - field: rmm_products
+    match_type: contains
+    value: "TeamViewer"
+    delta: 20
+
+  # --- Corroboration from other enrichments already in the pipeline ---
+  # Remote access reachable from a VPN egress is the pattern the reporting
+  # actually describes; on its own, remote access is just remote access.
+  - field: vpn_provider
+    match_type: contains
+    value: "astrill"
+    delta: 25
+  - field: vpn_provider
+    match_type: contains
+    value: "mullvad"
+    delta: 10
+  - field: proxy_detected
+    match_type: exact
+    value: "yes"
+    delta: 10
+
+  # --- Deliberate negatives: ubiquitous services, heavy false-positive risk ---
+  # RDP and VNC appear on a large share of the internet. They are recorded for
+  # completeness but must not, alone, push a row toward a confident match.
+  - field: rmm_products
+    match_type: exact
+    value: "RDP"
+    delta: -25
+  - field: rmm_products
+    match_type: exact
+    value: "VNC"
+    delta: -20
+
+ttl_days: 30
+
+tags:
+  - "dprk"
+  - "it-worker"
+  - "remote-access"
+  - "ip-kvm"
+  - "T1219.003"
+  - "infrastructure"

--- a/scripts/enrich_rmm_exposure.py
+++ b/scripts/enrich_rmm_exposure.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+enrich_rmm_exposure.py
+
+Flags IP addresses exposing IP-KVM hardware or remote-management (RMM)
+services.
+
+Why this exists
+---------------
+2026 reporting on DPRK IT-worker operations (Google Cloud Threat Intelligence,
+Nisos, runZero) describes laptop farms built on IP-KVM devices -- PiKVM,
+TinyPilot, JetKVM -- with RMM tooling as the fallback layer where KVM hardware
+is unavailable. Those connections are reported to originate predominantly from
+Astrill VPN addresses, a population this pipeline already resolves.
+
+MITRE ATT&CK covers the technique as T1219.003 (Remote Access Hardware), with
+detection strategy DET0159 targeting TinyPilot and PiKVM specifically. DET0159
+is host-based -- USB enumeration, EDID announcements, mount paths -- which is
+unavailable to an external pipeline. This module provides the complementary
+network-side view: which of our known-bad IPs expose such a device publicly.
+
+Signatures come from runZero's IP-KVM survey (HTTP titles and favicon hashes)
+and vendor default ports.
+
+Design notes
+------------
+Detection uses Shodan *host lookups* rather than search queries. Host lookups
+are already proven in this pipeline (enrich_shodan.py) and work on every plan
+tier, so detection does not depend on search-filter entitlements.
+
+ASN sweeps do use search, but combine the ASN filter with the signature set in
+a single query per ASN, so a whole operator ASN costs roughly one credit rather
+than one per host.
+
+Usage:
+  python enrich_rmm_exposure.py --ip-list data/known_campaign_ips.txt \
+      --asn-seed data/kadnap_operator_asns.csv \
+      --output data/rmm_exposure.csv --budget 100
+"""
+
+import argparse
+import csv
+import ipaddress
+import json
+import logging
+import os
+import sys
+from typing import Dict, List, Optional
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+FIELDS = [
+    "ip", "source", "asn", "kvm_detected", "kvm_products",
+    "rmm_detected", "rmm_products", "exposure_evidence", "checked_date",
+]
+
+# --- Signatures -------------------------------------------------------------
+# IP-KVM: HTTP title substrings and favicon.ico mmh3 hashes, per runZero's
+# "Out-of-Band, Part 1: the new gen of IP KVMs & how to find them".
+# Favicon hashes matter because titles are trivially customised -- a rebranded
+# device still serves the stock favicon.
+
+KVM_SIGNATURES: Dict[str, Dict] = {
+    "PiKVM":            {"titles": ["pikvm", "pi-kvm"], "favicons": [-1040945478, -692926325]},
+    "TinyPilot":        {"titles": ["tinypilot"],       "favicons": [-996415781]},
+    "JetKVM":           {"titles": ["jetkvm"],          "favicons": [-1261329937]},
+    "GLKVM":            {"titles": ["glkvm"],           "favicons": [-186012304]},
+    "NanoKVM":          {"titles": ["nanokvm"],         "favicons": [1323732765]},
+    "BliKVM":           {"titles": ["blikvm"],          "favicons": []},
+    "Apache Guacamole": {"titles": ["apache guacamole", "guacamole"], "favicons": []},
+}
+
+# RMM: vendor default ports and product banner strings.
+RMM_SIGNATURES: Dict[str, Dict] = {
+    "RustDesk":   {"ports": [21115, 21116, 21117, 21118, 21119], "products": ["rustdesk"]},
+    "AnyDesk":    {"ports": [7070],  "products": ["anydesk"]},
+    "TeamViewer": {"ports": [5938],  "products": ["teamviewer"]},
+    "VNC":        {"ports": [5900, 5901], "products": ["vnc", "realvnc", "tightvnc"]},
+    "RDP":        {"ports": [3389],  "products": ["remote desktop", "ms-wbt-server"]},
+}
+
+# 21118/21119 are RustDesk web-client ports only in some deployments; excluded
+# from the default port match to avoid claiming any high port is RustDesk.
+RUSTDESK_CORE_PORTS = {21115, 21116, 21117}
+
+
+def _iter_services(host: Dict):
+    for entry in host.get("data") or []:
+        if isinstance(entry, dict):
+            yield entry
+
+
+def classify_host(host: Dict) -> Dict:
+    """Classify a Shodan host record for KVM / RMM exposure.
+
+    Pure function: takes the record, returns findings. No network access, so
+    the signature logic is fully testable.
+    """
+    kvm_found: List[str] = []
+    rmm_found: List[str] = []
+    evidence: List[str] = []
+
+    for svc in _iter_services(host):
+        port = svc.get("port")
+        product = (svc.get("product") or "").lower()
+        http = svc.get("http") or {}
+        title = (http.get("title") or "").lower()
+        favicon = ((http.get("favicon") or {}).get("hash"))
+
+        # --- IP-KVM ---
+        for name, sig in KVM_SIGNATURES.items():
+            hit = None
+            if title and any(t in title for t in sig.get("titles", [])):
+                hit = "title"
+            elif favicon is not None and favicon in sig.get("favicons", []):
+                hit = "favicon"
+            if hit:
+                if name not in kvm_found:
+                    kvm_found.append(name)
+                evidence.append(f"{port}:{name}({hit})")
+
+        # --- RMM ---
+        for name, sig in RMM_SIGNATURES.items():
+            ports = sig.get("ports", [])
+            if name == "RustDesk":
+                ports = [p for p in ports if p in RUSTDESK_CORE_PORTS]
+            hit = None
+            if port in ports:
+                hit = "port"
+            elif product and any(p in product for p in sig.get("products", [])):
+                hit = "product"
+            if hit:
+                if name not in rmm_found:
+                    rmm_found.append(name)
+                evidence.append(f"{port}:{name}({hit})")
+
+    return {
+        "kvm_detected": bool(kvm_found),
+        "kvm_products": ";".join(kvm_found),
+        "rmm_detected": bool(rmm_found),
+        "rmm_products": ";".join(rmm_found),
+        "exposure_evidence": "; ".join(evidence),
+    }
+
+
+def load_ip_list(path: str) -> List[str]:
+    """Read a plain IP list, skipping blanks and # comments."""
+    ips: List[str] = []
+    if not os.path.exists(path):
+        log.warning(f"IP list not found: {path}")
+        return ips
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            try:
+                ipaddress.ip_address(line)
+            except ValueError:
+                continue
+            if line not in ips:
+                ips.append(line)
+    log.info(f"Loaded {len(ips)} IPs from {path}")
+    return ips
+
+
+def load_asn_seed(path: str) -> List[Dict]:
+    """Read the curated operator-ASN seed (ASN,Name,... )."""
+    rows: List[Dict] = []
+    if not os.path.exists(path):
+        log.info(f"No ASN seed at {path}; skipping ASN sweep")
+        return rows
+    with open(path, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            asn = (row.get("ASN") or "").strip()
+            if asn:
+                rows.append(row)
+    log.info(f"Loaded {len(rows)} operator ASNs from {path}")
+    return rows
+
+
+def kvm_search_query() -> str:
+    """One query covering every KVM title, for ASN sweeps.
+
+    Shodan's query language supports neither boolean OR nor parentheses.
+    Multiple alternatives for a single filter are comma-separated, so all
+    titles go into one http.title: filter. Combining that with the ASN filter
+    costs about one credit per ASN, instead of one host lookup per address in
+    the range.
+    """
+    titles = sorted({t for sig in KVM_SIGNATURES.values() for t in sig.get("titles", [])})
+    return "http.title:" + ",".join(f'"{t}"' for t in titles)
+
+
+def lookup_host(api, ip: str, cache=None):
+    """Shodan host lookup, cached.
+
+    Returns (record, used_api). record is None when the IP is unknown to
+    Shodan. used_api is False on a cache hit, so cached results do not consume
+    the run's API budget -- otherwise a re-run burns budget without making a
+    single call.
+    """
+    key = f"rmm_host:{ip}"
+    if cache is not None:
+        hit = cache.get(key, max_age_days=30)
+        if hit is not None:
+            return hit, False
+    try:
+        # minify=False: the per-service banner detail (product, http.title,
+        # favicon) is exactly what the signatures match on.
+        rec = api.host(ip, minify=False)
+    except Exception as e:
+        msg = str(e)
+        if "No information available" in msg:
+            log.debug(f"{ip}: not in Shodan")
+            return None, True
+        log.warning(f"{ip}: lookup failed: {type(e).__name__}: {msg}")
+        return None, True
+    if cache is not None:
+        try:
+            cache.set(key, rec)
+        except Exception:
+            pass
+    return rec, True
+
+
+ANNOTATION_FIELDS = [
+    "kvm_detected", "kvm_products", "rmm_detected", "rmm_products",
+    "exposure_evidence",
+]
+
+
+def annotate_csv(input_path: str, output_path: str, findings: Dict[str, Dict],
+                 ip_column: str = "a_record") -> int:
+    """Join findings onto a domain CSV, keyed by its IP column.
+
+    Mirrors enrich_proxy_check.py, so the fingerprint engine can match these
+    columns the same way FP-0010 matches proxy_detected / proxy_type.
+
+    Booleans are written as yes/no to match the existing enrichment columns.
+    Rows without a finding get an explicit "no" rather than a blank, so a
+    fingerprint can distinguish "checked, clean" from "never checked".
+
+    Returns the number of rows annotated with a positive finding.
+    """
+    with open(input_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+
+    for name in ANNOTATION_FIELDS:
+        if name not in fieldnames:
+            fieldnames.append(name)
+
+    annotated = 0
+    for row in rows:
+        ip = (row.get(ip_column) or "").strip()
+        found = findings.get(ip)
+        if found:
+            row["kvm_detected"] = "yes" if found["kvm_detected"] else "no"
+            row["rmm_detected"] = "yes" if found["rmm_detected"] else "no"
+            row["kvm_products"] = found["kvm_products"]
+            row["rmm_products"] = found["rmm_products"]
+            row["exposure_evidence"] = found["exposure_evidence"]
+            if found["kvm_detected"] or found["rmm_detected"]:
+                annotated += 1
+        else:
+            row.setdefault("kvm_detected", "no")
+            row.setdefault("rmm_detected", "no")
+            for name in ("kvm_products", "rmm_products", "exposure_evidence"):
+                row.setdefault(name, "")
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(rows)
+
+    log.info(f"Annotated {annotated} row(s) with exposure in {output_path}")
+    return annotated
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Flag IPs exposing IP-KVM or remote-management services")
+    parser.add_argument("--ip-list", default="data/known_campaign_ips.txt",
+                        help="Plain-text IP list (# comments allowed)")
+    parser.add_argument("--asn-seed", default="data/kadnap_operator_asns.csv",
+                        help="Curated operator-ASN CSV for the ASN sweep")
+    parser.add_argument("--output", default="data/rmm_exposure.csv")
+    parser.add_argument("--budget", type=int, default=100,
+                        help="Maximum Shodan calls this run")
+    parser.add_argument("--skip-asn-sweep", action="store_true",
+                        help="Host lookups only; makes no search queries")
+    parser.add_argument("--annotate", default=None,
+                        help="Domain CSV to join findings onto (adds columns in place)")
+    parser.add_argument("--ip-column", default="a_record",
+                        help="Column in --annotate holding the IP to match")
+    args = parser.parse_args()
+
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except Exception:
+        pass
+
+    api_key = os.getenv("SHODAN_API_KEY")
+    if not api_key:
+        log.error("SHODAN_API_KEY not set")
+        return 1
+
+    import shodan
+    api = shodan.Shodan(api_key)
+
+    try:
+        from shodan_utils import ShodanCache
+        cache = ShodanCache()
+    except Exception as e:
+        log.warning(f"Cache unavailable ({e}); continuing uncached")
+        cache = None
+
+    from datetime import date
+    today = date.today().isoformat()
+    results: List[Dict] = []
+    spent = 0
+
+    # --- 1. Known campaign IPs -------------------------------------------
+    for ip in load_ip_list(args.ip_list):
+        if spent >= args.budget:
+            log.warning(f"Budget of {args.budget} reached; {ip} onwards not checked")
+            break
+        rec, used_api = lookup_host(api, ip, cache)
+        if used_api:
+            spent += 1
+        if rec is None:
+            continue
+        found = classify_host(rec)
+        if found["kvm_detected"] or found["rmm_detected"]:
+            log.info(f"  {ip}: {found['exposure_evidence']}")
+        results.append({
+            "ip": ip,
+            "source": os.path.basename(args.ip_list),
+            "asn": rec.get("asn", ""),
+            "checked_date": today,
+            **found,
+        })
+
+    # --- 2. Operator ASN sweep -------------------------------------------
+    if not args.skip_asn_sweep:
+        query_sigs = kvm_search_query()
+        for row in load_asn_seed(args.asn_seed):
+            if spent >= args.budget:
+                log.warning("Budget reached; ASN sweep truncated")
+                break
+            asn = row["ASN"].strip()
+            q = f"asn:{asn} {query_sigs}"
+            try:
+                res = api.search(q, limit=100)
+                spent += 1
+            except Exception as e:
+                log.warning(f"{asn}: search failed: {type(e).__name__}: {e}")
+                continue
+            total = res.get("total", 0)
+            log.info(f"  {asn} ({row.get('Name','')}): {total} KVM-signature match(es)")
+            for match in res.get("matches", []):
+                found = classify_host({"data": [match]})
+                results.append({
+                    "ip": match.get("ip_str", ""),
+                    "source": f"asn_sweep:{asn}",
+                    "asn": asn,
+                    "checked_date": today,
+                    **found,
+                })
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=FIELDS)
+        w.writeheader()
+        w.writerows(results)
+
+    if args.annotate:
+        by_ip = {r["ip"]: r for r in results if r.get("ip")}
+        annotate_csv(args.annotate, args.annotate, by_ip, args.ip_column)
+
+    hits = [r for r in results if r["kvm_detected"] or r["rmm_detected"]]
+    log.info(f"Wrote {len(results)} rows to {args.output} ({len(hits)} with exposure)")
+    log.info(f"Shodan calls used: {spent}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_rmm_exposure.py
+++ b/tests/test_rmm_exposure.py
@@ -1,0 +1,227 @@
+"""Tests for IP-KVM / remote-management exposure detection.
+
+Signatures are drawn from runZero's IP-KVM survey (HTTP titles and favicon
+hashes) and vendor default ports. The classifier is deliberately pure -- it
+takes a Shodan host record and returns findings -- so it needs no API access.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from enrich_rmm_exposure import classify_host, KVM_SIGNATURES, RMM_SIGNATURES
+
+
+def host(*services, ip="203.0.113.10", ports=None):
+    """Build a minimal Shodan host record."""
+    return {
+        "ip_str": ip,
+        "ports": ports if ports is not None else [s.get("port") for s in services],
+        "data": list(services),
+    }
+
+
+def svc(port, product=None, title=None, favicon=None):
+    entry = {"port": port}
+    if product:
+        entry["product"] = product
+    http = {}
+    if title:
+        http["title"] = title
+    if favicon:
+        http["favicon"] = {"hash": favicon}
+    if http:
+        entry["http"] = http
+    return entry
+
+
+class TestKVMDetection:
+    def test_pikvm_by_title(self):
+        r = classify_host(host(svc(443, title="PiKVM - Login")))
+        assert r["kvm_detected"] is True
+        assert "PiKVM" in r["kvm_products"]
+
+    def test_pikvm_alternate_title_spelling(self):
+        """runZero documents both 'PiKVM' and 'Pi-KVM'."""
+        r = classify_host(host(svc(443, title="Pi-KVM Web Terminal")))
+        assert r["kvm_detected"] is True
+        assert "PiKVM" in r["kvm_products"]
+
+    def test_tinypilot_by_favicon_hash(self):
+        """Title can be customised; the favicon hash still gives it away."""
+        r = classify_host(host(svc(80, title="Server Room", favicon=-996415781)))
+        assert r["kvm_detected"] is True
+        assert "TinyPilot" in r["kvm_products"]
+
+    def test_jetkvm_by_title(self):
+        r = classify_host(host(svc(80, title="JetKVM")))
+        assert r["kvm_detected"] is True
+        assert "JetKVM" in r["kvm_products"]
+
+    def test_guacamole_by_title(self):
+        r = classify_host(host(svc(8080, title="Apache Guacamole")))
+        assert r["kvm_detected"] is True
+        assert "Apache Guacamole" in r["kvm_products"]
+
+    def test_title_match_is_case_insensitive(self):
+        r = classify_host(host(svc(443, title="pikvm")))
+        assert r["kvm_detected"] is True
+
+
+class TestRMMDetection:
+    def test_rustdesk_by_port(self):
+        r = classify_host(host(svc(21116)))
+        assert r["rmm_detected"] is True
+        assert "RustDesk" in r["rmm_products"]
+
+    def test_anydesk_by_port(self):
+        r = classify_host(host(svc(7070)))
+        assert r["rmm_detected"] is True
+        assert "AnyDesk" in r["rmm_products"]
+
+    def test_teamviewer_by_port(self):
+        r = classify_host(host(svc(5938)))
+        assert r["rmm_detected"] is True
+        assert "TeamViewer" in r["rmm_products"]
+
+    def test_product_banner_match(self):
+        r = classify_host(host(svc(443, product="TeamViewer")))
+        assert r["rmm_detected"] is True
+        assert "TeamViewer" in r["rmm_products"]
+
+
+class TestNoFalsePositives:
+    def test_ordinary_webserver_is_clean(self):
+        r = classify_host(host(svc(80, product="nginx", title="Welcome to nginx!"),
+                               svc(443, product="nginx")))
+        assert r["kvm_detected"] is False
+        assert r["rmm_detected"] is False
+        assert r["kvm_products"] == ""
+        assert r["rmm_products"] == ""
+
+    def test_empty_host_record_is_clean(self):
+        r = classify_host({"ip_str": "203.0.113.1", "ports": [], "data": []})
+        assert r["kvm_detected"] is False
+        assert r["rmm_detected"] is False
+
+    def test_missing_data_key_does_not_raise(self):
+        r = classify_host({"ip_str": "203.0.113.1"})
+        assert r["kvm_detected"] is False
+
+    def test_unrelated_high_port_is_clean(self):
+        """A high port that is not a known RMM default must not match."""
+        r = classify_host(host(svc(21118)))
+        assert r["rmm_detected"] is False
+
+
+class TestCombinedFindings:
+    def test_kvm_and_rmm_together(self):
+        r = classify_host(host(svc(443, title="PiKVM"), svc(21116)))
+        assert r["kvm_detected"] is True
+        assert r["rmm_detected"] is True
+
+    def test_multiple_products_are_all_listed(self):
+        r = classify_host(host(svc(7070), svc(5938)))
+        assert "AnyDesk" in r["rmm_products"]
+        assert "TeamViewer" in r["rmm_products"]
+
+    def test_products_are_deduplicated(self):
+        r = classify_host(host(svc(21115), svc(21116), svc(21117)))
+        assert r["rmm_products"].count("RustDesk") == 1
+
+    def test_evidence_records_what_matched(self):
+        """A finding must be explainable without re-querying Shodan."""
+        r = classify_host(host(svc(443, title="PiKVM - Login")))
+        assert "443" in r["exposure_evidence"]
+        assert "PiKVM" in r["exposure_evidence"]
+
+
+class TestSignatureTables:
+    def test_signature_tables_are_populated(self):
+        assert len(KVM_SIGNATURES) >= 6, "expected the runZero IP-KVM set"
+        assert len(RMM_SIGNATURES) >= 4
+
+    def test_every_kvm_signature_has_a_matcher(self):
+        for name, sig in KVM_SIGNATURES.items():
+            assert sig.get("titles") or sig.get("favicons"), f"{name} has no matcher"
+
+    def test_every_rmm_signature_has_a_matcher(self):
+        for name, sig in RMM_SIGNATURES.items():
+            assert sig.get("ports") or sig.get("products"), f"{name} has no matcher"
+
+
+class TestSearchQuerySyntax:
+    """Shodan supports neither OR nor parentheses; alternatives are comma-separated.
+
+    A live run against five operator ASNs returned
+    'APIError: The search query was invalid' for every one, because the query
+    was built with ' OR ' and wrapped in parentheses.
+    """
+
+    def test_query_uses_no_boolean_or(self):
+        from enrich_rmm_exposure import kvm_search_query
+        q = kvm_search_query()
+        assert " OR " not in q, f"Shodan rejects boolean OR: {q}"
+        assert "(" not in q and ")" not in q, f"Shodan rejects parentheses: {q}"
+
+    def test_query_is_a_single_comma_separated_title_filter(self):
+        from enrich_rmm_exposure import kvm_search_query
+        q = kvm_search_query()
+        assert q.count("http.title:") == 1, f"expected one filter, got: {q}"
+        assert '"pikvm"' in q and '"tinypilot"' in q
+
+
+class TestAnnotateCsv:
+    """Findings must be joinable onto domain rows, which is what the
+    fingerprint engine matches against (see FP-0010 consuming
+    proxy_detected/proxy_type from enrich_proxy_check.py)."""
+
+    def _domains(self, tmp_path):
+        import csv
+        p = tmp_path / "domains.csv"
+        with open(p, "w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=["domain", "a_record"])
+            w.writeheader()
+            w.writerow({"domain": "bad.example", "a_record": "203.0.113.10"})
+            w.writerow({"domain": "clean.example", "a_record": "203.0.113.99"})
+            w.writerow({"domain": "noip.example", "a_record": ""})
+        return str(p)
+
+    def test_annotates_matching_rows_and_preserves_others(self, tmp_path):
+        import csv
+        from enrich_rmm_exposure import annotate_csv
+
+        src = self._domains(tmp_path)
+        out = str(tmp_path / "out.csv")
+        findings = {
+            "203.0.113.10": {
+                "kvm_detected": True, "kvm_products": "PiKVM",
+                "rmm_detected": False, "rmm_products": "",
+                "exposure_evidence": "443:PiKVM(title)",
+            }
+        }
+        n = annotate_csv(src, out, findings, ip_column="a_record")
+
+        rows = {r["domain"]: r for r in csv.DictReader(open(out, encoding="utf-8"))}
+        assert n == 1
+        assert rows["bad.example"]["kvm_detected"] == "yes"
+        assert rows["bad.example"]["kvm_products"] == "PiKVM"
+        assert rows["bad.example"]["exposure_evidence"] == "443:PiKVM(title)"
+        # untouched rows keep their data and get empty, not missing, columns
+        assert rows["clean.example"]["kvm_detected"] == "no"
+        assert rows["noip.example"]["domain"] == "noip.example"
+
+    def test_existing_columns_are_not_duplicated(self, tmp_path):
+        import csv
+        from enrich_rmm_exposure import annotate_csv
+
+        src = self._domains(tmp_path)
+        out = str(tmp_path / "out.csv")
+        annotate_csv(src, out, {}, ip_column="a_record")
+        annotate_csv(out, out, {}, ip_column="a_record")
+
+        header = next(csv.reader(open(out, encoding="utf-8")))
+        assert header.count("kvm_detected") == 1, header


### PR DESCRIPTION
Implements **Phase 5** of the remediation plan — the capability gap from the audit.

## Why

2026 reporting ([Google Cloud Threat Intelligence](https://cloud.google.com/blog/topics/threat-intelligence/mitigating-dprk-it-worker-threat), [Nisos](https://nisos.com/blog/dprk-it-worker-fraud-laptop-farm/), [runZero](https://www.runzero.com/blog/oob-p1-ip-kvm/)) describes DPRK laptop farms built on IP-KVM devices, with RMM tooling as the fallback layer — and notes those connections originate predominantly from **Astrill** addresses, a population this pipeline already resolves. The repo previously had **no reference to any remote-access product**.

MITRE covers this as **T1219.003 (Remote Access Hardware)**. Detection strategy DET0159 targets TinyPilot/PiKVM but is host-based (USB enumeration, EDID, mount paths) — unavailable to an external pipeline. This is the complementary network-side view.

## Design

`classify_host()` is a **pure function** over a Shodan host record, so signature logic is fully testable without API access.

Detection uses **host lookups, not search**, so it doesn't depend on search-filter entitlements — the same API surface `enrich_shodan.py` already proves works. ASN sweeps do use search, but pack every signature into one query per ASN: an operator ASN costs ~1 credit instead of one per address.

Signatures are runZero's: HTTP titles **plus favicon hashes** for PiKVM, TinyPilot, JetKVM, GLKVM, NanoKVM, BliKVM, Guacamole. Favicon hashes matter because titles are trivially customised — a rebranded device still serves the stock favicon.

`--annotate` joins findings onto a domain CSV by IP column, mirroring `enrich_proxy_check.py`. That's how the fingerprint engine consumes them.

## Two defects found by running it live, not just testing it

**Shodan supports neither `OR` nor parentheses.** The first ASN sweep returned `APIError: The search query was invalid` for all five ASNs. Alternatives for a single filter are comma-separated. There's now a test asserting the query contains no `OR` and no parens.

**Cache hits were charged against the API budget**, so a re-run burned budget without making a call. `lookup_host` now reports whether it actually hit the API.

## Scoring — rarity drives confidence

| Signal | Δ | Reasoning |
|---|---|---|
| PiKVM / TinyPilot / JetKVM / NanoKVM / GLKVM / BliKVM | +30 | dedicated KVM hardware on the public internet is unusual |
| Apache Guacamole | +15 | also a legitimate enterprise gateway |
| RustDesk / AnyDesk / TeamViewer | +20 | named in the reporting, but ordinary IT tooling too |
| Astrill egress | +25 | remote access *reachable from a VPN egress* is the actual reported pattern |
| **RDP** | **−25** | ubiquitous; must not carry a match alone |
| **VNC** | **−20** | ubiquitous |

## Live validation

143 known campaign IPs + 5 KadNap operator ASNs, 37 API calls:

```
43.129.36.127    AS132203   RDP        3389
65.20.91.12      AS20473    RDP        3389
120.76.157.134   AS37963    RustDesk   21116
23.227.173.144   AS29802    Guacamole  3000   <- Hivelocity, KadNap-prev-C2 ASN
```

The Guacamole host also runs Nginx Proxy Manager on 81 and OpenSSH on 22.

**Read that finding carefully:** AS29802 is Hivelocity, a large shared host with thousands of unrelated customers. A Guacamole instance somewhere in that ASN is a **lead, not an attribution** — which is why the fingerprint weights corroborating signals above the raw detection.

## Note

The CI step passes `--asn-seed data/kadnap_operator_asns.csv`, which currently exists only on the unpushed `intel/kadnap-doppelganger` branch. The script no-ops cleanly when the seed is absent, so the ASN sweep simply stays dormant until that branch lands.

## Verification

- [x] 25 new tests; **783 pass** overall
- [x] FP-0011 loads through the real engine; all match types valid
- [x] CI step ordered **before** Infrastructure Fingerprinting, else matches defer a day
- [ ] Live CI run populates `rmm_exposure.csv` and FP-0011 appears in `fingerprint_matches.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
