### PR TITLE
fix: restore Shodan org discovery for VPN providers

### DIFF
--- a/.github/workflows/update_intelligence.yml
+++ b/.github/workflows/update_intelligence.yml
@@ -222,6 +222,12 @@ jobs:
           # Was causing 3+ hour runtimes on full dataset.
 
       - name: Infrastructure Intel (ASN/VPN/Tor)
+        env:
+          # vpn_ip_intel.py discovers Astrill, Urban VPN, ExpressVPN and
+          # Hotspot Shield IPs via Shodan org search. Without this the search
+          # silently returns nothing and those providers fall back to their
+          # seed lists -- Astrill's is from 2024.
+          SHODAN_API_KEY: ${{ secrets.SHODAN_API_KEY }}
         run: |
           python scripts/asn_intel.py
           python scripts/vpn_intel.py

--- a/scripts/vpn_ip_intel.py
+++ b/scripts/vpn_ip_intel.py
@@ -19,6 +19,11 @@ import os
 import re
 import subprocess
 import requests
+
+try:
+    import shodan
+except ImportError:  # optional at import time; guarded at call site
+    shodan = None
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
@@ -98,24 +103,52 @@ class BaseProvider(ABC):
         raise NotImplementedError
 
     @staticmethod
-    def shodan_org_search(org_name: str) -> set:
-        """Use Shodan CLI search (free query) to find IPs attributed to an org."""
-        try:
-            result = subprocess.run(
-                ["shodan", "search", "--fields", "ip_str",
-                 f'org:"{org_name}"', "--limit", "1000"],
-                capture_output=True, text=True, timeout=60
+    def shodan_org_search(org_name: str, limit: int = 1000) -> set:
+        """Find IPs Shodan attributes to an organisation.
+
+        Uses the Python API rather than the `shodan` CLI. The CLI reads its key
+        from ~/.shodan/api_key, written by `shodan init`, and ignores the
+        environment -- so in CI it was never authenticated and this returned an
+        empty set for every provider that relies on it (Astrill, Urban VPN,
+        ExpressVPN, Hotspot Shield). Because only FileNotFoundError and
+        TimeoutExpired were caught, that was indistinguishable from a genuine
+        "no results", and every committed dataset carried zero rows from a
+        shodan source while Astrill fell back entirely to a 2024 seed.
+
+        Failures are logged at ERROR and return an empty set, so the caller
+        degrades to its seed rather than crashing -- but the log now says which
+        happened.
+        """
+        api_key = os.getenv("SHODAN_API_KEY")
+        if not api_key:
+            logger.error(
+                f"SHODAN_API_KEY not set - org search for '{org_name}' skipped. "
+                f"Providers relying on it will fall back to their seed lists."
             )
-            ips = set()
-            for line in result.stdout.splitlines():
-                ip = line.strip().split("\t")[0] if "\t" in line else line.strip()
-                if ip and ip[0].isdigit():
-                    ips.add(ip)
-            logger.info(f"  Shodan org:{org_name}: {len(ips)} IPs")
-            return ips
-        except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-            logger.warning(f"Shodan CLI not available or timed out: {e}")
             return set()
+        if shodan is None:
+            logger.error("shodan package not installed; org search skipped")
+            return set()
+
+        ips = set()
+        try:
+            api = shodan.Shodan(api_key)
+            for match in api.search_cursor(f'org:"{org_name}"'):
+                ip = match.get("ip_str")
+                if ip:
+                    ips.add(ip)
+                if len(ips) >= limit:
+                    logger.info(f"  Shodan org:{org_name}: hit limit of {limit}")
+                    break
+        except Exception as e:
+            logger.error(f"Shodan org search for '{org_name}' failed: {type(e).__name__}: {e}")
+            return set()
+
+        if ips:
+            logger.info(f"  Shodan org:{org_name}: {len(ips)} IPs")
+        else:
+            logger.warning(f"  Shodan org:{org_name}: 0 IPs - verify the org name is current")
+        return ips
 
 
 class MullvadProvider(BaseProvider):

--- a/tests/test_vpn_ip_intel.py
+++ b/tests/test_vpn_ip_intel.py
@@ -1387,3 +1387,64 @@ class TestLogScaleLookup:
         text = open(path, encoding="utf-8").read()
         # compact separators -> no ", " or ": " whitespace
         assert ", " not in text and ": " not in text
+
+
+# === Shodan org search (provider discovery) ===
+
+class TestShodanOrgSearch:
+    """Astrill, Urban VPN, ExpressVPN and Hotspot Shield all discover IPs
+    through BaseProvider.shodan_org_search.
+
+    It used to shell out to the `shodan` CLI, which authenticates from
+    ~/.shodan/api_key rather than the environment. The CI step running
+    vpn_ip_intel.py set no SHODAN_API_KEY at all, so the search returned
+    nothing -- and because only FileNotFoundError and TimeoutExpired were
+    caught, an auth failure was indistinguishable from "no results". Every
+    committed dataset had zero rows from a shodan source.
+    """
+
+    def test_returns_ips_from_api(self):
+        from unittest.mock import patch, MagicMock
+        fake = MagicMock()
+        fake.search_cursor.return_value = iter([
+            {"ip_str": "1.2.3.4"}, {"ip_str": "5.6.7.8"}, {"ip_str": "1.2.3.4"},
+        ])
+        with patch.dict(os.environ, {"SHODAN_API_KEY": "k"}):
+            with patch("vpn_ip_intel.shodan") as mod:
+                mod.Shodan.return_value = fake
+                ips = BaseProvider.shodan_org_search("Astrill Systems Corp")
+        assert ips == {"1.2.3.4", "5.6.7.8"}
+
+    def test_missing_key_returns_empty_and_does_not_raise(self):
+        from unittest.mock import patch
+        env = {k: v for k, v in os.environ.items() if k != "SHODAN_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            assert BaseProvider.shodan_org_search("Astrill Systems Corp") == set()
+
+    def test_api_error_returns_empty_and_does_not_raise(self):
+        from unittest.mock import patch, MagicMock
+        fake = MagicMock()
+        fake.search_cursor.side_effect = RuntimeError("boom")
+        with patch.dict(os.environ, {"SHODAN_API_KEY": "k"}):
+            with patch("vpn_ip_intel.shodan") as mod:
+                mod.Shodan.return_value = fake
+                assert BaseProvider.shodan_org_search("X") == set()
+
+    def test_respects_limit(self):
+        from unittest.mock import patch, MagicMock
+        fake = MagicMock()
+        fake.search_cursor.return_value = iter(
+            [{"ip_str": f"10.0.0.{i}"} for i in range(1, 60)])
+        with patch.dict(os.environ, {"SHODAN_API_KEY": "k"}):
+            with patch("vpn_ip_intel.shodan") as mod:
+                mod.Shodan.return_value = fake
+                ips = BaseProvider.shodan_org_search("X", limit=10)
+        assert len(ips) == 10
+
+    def test_does_not_shell_out_to_the_cli(self):
+        """The CLI reads ~/.shodan/api_key, not the environment, so CI could
+        never authenticate it."""
+        import inspect
+        src = inspect.getsource(BaseProvider.shodan_org_search)
+        assert "subprocess" not in src, "org search must use the API, not the CLI"
+


### PR DESCRIPTION
Replaces the blocked Phase 4. **There is no newer Spur seed available**, so instead of refreshing Astrill's source, this fixes why its *other* discovery path produces nothing.

## The finding

**Every committed dataset has zero rows from a `shodan` source.**

```
rows with a shodan-derived source: 0
```

Four providers depend on `BaseProvider.shodan_org_search`: **Astrill, Urban VPN, ExpressVPN, Hotspot Shield**. All four have been getting nothing.

## Two causes, both silent

**1 · The CLI was never authenticated.** The search shelled out to the `shodan` CLI, which reads `~/.shodan/api_key` written by `shodan init` — it does not read the environment. And the workflow step running `vpn_ip_intel.py` had **no `env:` block at all**, so no key existed in any form. The step is `continue-on-error`, so nothing surfaced.

**2 · Failure looked identical to success.** Only `FileNotFoundError` and `TimeoutExpired` were caught. An unauthenticated CLI exits non-zero with empty stdout, which the parser read as "no results" — a broken credential was indistinguishable from a genuine empty answer.

## Why it matters most for Astrill

Astrill is the **highest-weighted indicator** in `vpn_provider_scores.csv` (25 prehire / 30 posthire, `VPN-001`). With discovery dead it fell back entirely to `spur_astrill_2024.txt` — 2,403 IPs, all dated `2024-01-01`:

```
1470  source=spur_2024        conf=medium      date=2024-01-01
 933  source=spur_2024+rdap   conf=confirmed   date=2024-01-01
   0  source=shodan_org
```

## Fix

`shodan_org_search` now uses the **Python API**, which reads `SHODAN_API_KEY` from the environment, paging via `search_cursor` up to a caller-supplied limit.

Failures are no longer ambiguous:
- missing key → `ERROR` naming the consequence
- empty result → `WARNING` suggesting the org name may be stale
- exception → caught, logged, degrades to the seed rather than crashing

The workflow step now passes `SHODAN_API_KEY`.

## Live result

```
Astrill Systems Corp    68 IPs    (previously 0)
ExpressVPN             300 IPs    (limit; more available)
Urban VPN                0 IPs    (warning fires - org name likely wrong)
```

Astrill's 68 are fresh, dated today, recorded at confidence `high` — not 2024-vintage seed entries. **This does not replace a current Spur seed**, but it does mean the provider is no longer wholly dependent on one.

Urban VPN returning zero is deliberately left alone: the new warning makes it visible, and guessing at the right org string would just re-hide it.

## Verification

- [x] 5 new tests, incl. one asserting the implementation doesn't shell out to the CLI
- [x] **788 pass**
- [x] Live API confirms 68 Astrill IPs discoverable
- [ ] Next CI run produces rows with `source=shodan_org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
