### PR TITLE
feat(rmm): sweep favicons, detect MeshCentral, target the domain set

### DIFF
--- a/.github/workflows/update_intelligence.yml
+++ b/.github/workflows/update_intelligence.yml
@@ -279,7 +279,7 @@ jobs:
           python scripts/enrich_spf.py -i /tmp/actor_mx_domains.txt -o data/spf_enrichment.csv -c 200
 
       - name: RMM / IP-KVM Exposure Enrichment
-        timeout-minutes: 15
+        timeout-minutes: 20
         continue-on-error: true
         env:
           SHODAN_API_KEY: ${{ secrets.SHODAN_API_KEY }}
@@ -288,7 +288,12 @@ jobs:
           # kvm_detected / rmm_detected columns this step writes, so running it
           # afterwards would defer every match to the following day's run.
           if [ -n "$SHODAN_API_KEY" ]; then
-            python scripts/enrich_rmm_exposure.py               --ip-list data/known_campaign_ips.txt               --asn-seed data/kadnap_operator_asns.csv               --output data/rmm_exposure.csv               --annotate data/dea_domains_probed.csv               --budget 300
+            # Shodan host lookups consume no query credits (measured: 145
+            # lookups + 15 searches cost 99 credits, all from the searches), so
+            # the limit here is wall clock at ~1 req/s, not cost. The domain set
+            # resolves to ~31.7k unique IPs; a bounded slice runs each day and
+            # the 30-day cache carries progress forward.
+            python scripts/enrich_rmm_exposure.py               --ip-list data/known_campaign_ips.txt               --domain-csv data/dea_domains_probed.csv               --ip-column a_record               --asn-seed data/kadnap_operator_asns.csv               --output data/rmm_exposure.csv               --annotate data/dea_domains_probed.csv               --budget 1000
           fi
           cp data/rmm_exposure.csv docs/data/ || true
 

--- a/scripts/enrich_rmm_exposure.py
+++ b/scripts/enrich_rmm_exposure.py
@@ -80,6 +80,11 @@ RMM_SIGNATURES: Dict[str, Dict] = {
     "TeamViewer": {"ports": [5938],  "products": ["teamviewer"]},
     "VNC":        {"ports": [5900, 5901], "products": ["vnc", "realvnc", "tightvnc"]},
     "RDP":        {"ports": [3389],  "products": ["remote desktop", "ms-wbt-server"]},
+    # Self-hosted RMM. Surfaced by passive DNS on 23.227.173.144, which served
+    # mesh.<domain> beside rust.<domain> -- MeshCentral running next to
+    # RustDesk. It has no fixed port worth matching (commonly 443 or 8086), so
+    # it is identified by title and banner only.
+    "MeshCentral": {"ports": [], "products": ["meshcentral"], "titles": ["meshcentral"]},
 }
 
 # 21118/21119 are RustDesk web-client ports only in some deployments; excluded
@@ -128,10 +133,12 @@ def classify_host(host: Dict) -> Dict:
             if name == "RustDesk":
                 ports = [p for p in ports if p in RUSTDESK_CORE_PORTS]
             hit = None
-            if port in ports:
+            if ports and port in ports:
                 hit = "port"
             elif product and any(p in product for p in sig.get("products", [])):
                 hit = "product"
+            elif title and any(x in title for x in sig.get("titles", [])):
+                hit = "title"
             if hit:
                 if name not in rmm_found:
                     rmm_found.append(name)
@@ -167,6 +174,37 @@ def load_ip_list(path: str) -> List[str]:
     return ips
 
 
+def load_ips_from_csv(path: str, column: str) -> List[str]:
+    """Unique, valid IPs from a column of a domain CSV, in first-seen order.
+
+    FP-0011 matches domain rows, so the addresses worth checking are the ones
+    those rows resolve to. Invalid and blank values are skipped rather than
+    raising -- a_record legitimately holds CNAMEs and error strings.
+    """
+    ips: List[str] = []
+    seen = set()
+    if not os.path.exists(path):
+        log.warning(f"CSV not found: {path}")
+        return ips
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if column not in (reader.fieldnames or []):
+            log.warning(f"Column '{column}' not in {path}; columns: {reader.fieldnames}")
+            return ips
+        for row in reader:
+            v = (row.get(column) or "").strip()
+            if not v or v in seen:
+                continue
+            try:
+                ipaddress.ip_address(v)
+            except ValueError:
+                continue
+            seen.add(v)
+            ips.append(v)
+    log.info(f"Loaded {len(ips)} unique IPs from {column} in {path}")
+    return ips
+
+
 def load_asn_seed(path: str) -> List[Dict]:
     """Read the curated operator-ASN seed (ASN,Name,... )."""
     rows: List[Dict] = []
@@ -193,6 +231,25 @@ def kvm_search_query() -> str:
     """
     titles = sorted({t for sig in KVM_SIGNATURES.values() for t in sig.get("titles", [])})
     return "http.title:" + ",".join(f'"{t}"' for t in titles)
+
+
+def kvm_favicon_queries() -> List[str]:
+    """One query per known KVM favicon hash.
+
+    Shodan cannot OR multiple values for http.favicon.hash the way it can for
+    http.title, so each hash needs its own query. Favicons matter because a
+    title is trivially customised while the stock favicon usually survives --
+    a retitled PiKVM is invisible to a title-only sweep.
+    """
+    hashes = sorted({h for sig in KVM_SIGNATURES.values() for h in sig.get("favicons", [])})
+    return [f"http.favicon.hash:{h}" for h in hashes]
+
+
+def asn_sweep_queries(asn: str) -> List[str]:
+    """Every sweep query for one ASN: the combined title filter, then one per
+    favicon hash. Costs len(favicons)+1 searches per ASN instead of 1, which is
+    still far cheaper than a host lookup per address in the range."""
+    return [f"asn:{asn} {kvm_search_query()}"] + [f"asn:{asn} {q}" for q in kvm_favicon_queries()]
 
 
 def lookup_host(api, ip: str, cache=None):
@@ -295,6 +352,11 @@ def main():
                         help="Maximum Shodan calls this run")
     parser.add_argument("--skip-asn-sweep", action="store_true",
                         help="Host lookups only; makes no search queries")
+    parser.add_argument("--domain-csv", default=None,
+                        help="Domain CSV to source IPs from (uses --ip-column). "
+                             "Processed after --ip-list, budget permitting; the "
+                             "30-day cache makes successive runs pick up where "
+                             "the last left off.")
     parser.add_argument("--annotate", default=None,
                         help="Domain CSV to join findings onto (adds columns in place)")
     parser.add_argument("--ip-column", default="a_record",
@@ -348,24 +410,51 @@ def main():
             **found,
         })
 
+    # --- 1b. IPs from a domain CSV ---------------------------------------
+    if args.domain_csv:
+        for ip in load_ips_from_csv(args.domain_csv, args.ip_column):
+            if spent >= args.budget:
+                log.info(f"Budget of {args.budget} reached; remaining IPs deferred "
+                         f"to the next run (cache carries progress forward)")
+                break
+            rec, used_api = lookup_host(api, ip, cache)
+            if used_api:
+                spent += 1
+            if rec is None:
+                continue
+            found = classify_host(rec)
+            if found["kvm_detected"] or found["rmm_detected"]:
+                log.info(f"  {ip}: {found['exposure_evidence']}")
+            results.append({
+                "ip": ip,
+                "source": os.path.basename(args.domain_csv),
+                "asn": rec.get("asn", ""),
+                "checked_date": today,
+                **found,
+            })
+
     # --- 2. Operator ASN sweep -------------------------------------------
     if not args.skip_asn_sweep:
-        query_sigs = kvm_search_query()
         for row in load_asn_seed(args.asn_seed):
             if spent >= args.budget:
                 log.warning("Budget reached; ASN sweep truncated")
                 break
             asn = row["ASN"].strip()
-            q = f"asn:{asn} {query_sigs}"
-            try:
-                res = api.search(q, limit=100)
-                spent += 1
-            except Exception as e:
-                log.warning(f"{asn}: search failed: {type(e).__name__}: {e}")
-                continue
-            total = res.get("total", 0)
-            log.info(f"  {asn} ({row.get('Name','')}): {total} KVM-signature match(es)")
-            for match in res.get("matches", []):
+            found_total = 0
+            matches = []
+            for q in asn_sweep_queries(asn):
+                if spent >= args.budget:
+                    break
+                try:
+                    res = api.search(q, limit=100)
+                    spent += 1
+                except Exception as e:
+                    log.warning(f"{asn}: search failed ({q}): {type(e).__name__}: {e}")
+                    continue
+                found_total += res.get("total", 0)
+                matches.extend(res.get("matches", []))
+            log.info(f"  {asn} ({row.get('Name','')}): {found_total} KVM-signature match(es)")
+            for match in matches:
                 found = classify_host({"data": [match]})
                 results.append({
                     "ip": match.get("ip_str", ""),

--- a/tests/test_rmm_exposure.py
+++ b/tests/test_rmm_exposure.py
@@ -225,3 +225,88 @@ class TestAnnotateCsv:
 
         header = next(csv.reader(open(out, encoding="utf-8")))
         assert header.count("kvm_detected") == 1, header
+
+
+class TestFaviconSweepQueries:
+    """The ASN sweep searched only http.title, while host lookups also matched
+    favicon hashes. A retitled device inside a swept ASN was therefore invisible
+    to the sweep but would have been caught by a direct lookup -- an asymmetry
+    worth closing, since retitling is trivial and replacing the favicon is not.
+    """
+
+    def test_favicon_query_is_built(self):
+        from enrich_rmm_exposure import kvm_favicon_queries
+        qs = kvm_favicon_queries()
+        assert qs, "expected at least one favicon query"
+        for q in qs:
+            assert q.startswith("http.favicon.hash:"), q
+            assert " OR " not in q and "(" not in q
+
+    def test_covers_every_known_favicon(self):
+        from enrich_rmm_exposure import kvm_favicon_queries, KVM_SIGNATURES
+        known = {h for s in KVM_SIGNATURES.values() for h in s.get("favicons", [])}
+        joined = " ".join(kvm_favicon_queries())
+        for h in known:
+            assert str(h) in joined, f"favicon {h} not covered by sweep"
+
+    def test_sweep_queries_combine_title_and_favicon(self):
+        from enrich_rmm_exposure import asn_sweep_queries
+        qs = asn_sweep_queries("AS29802")
+        assert all(q.startswith("asn:AS29802 ") for q in qs), qs
+        assert any("http.title:" in q for q in qs)
+        assert any("http.favicon.hash:" in q for q in qs)
+
+
+class TestMeshCentral:
+    """Found by passive DNS on 23.227.173.144: a mesh.<domain> hostname
+    alongside rust.<domain>, i.e. MeshCentral running next to RustDesk.
+    MeshCentral is a self-hosted RMM and was missing from the signatures.
+    """
+
+    def test_meshcentral_by_title(self):
+        r = classify_host(host(svc(443, title="MeshCentral")))
+        assert r["rmm_detected"] is True
+        assert "MeshCentral" in r["rmm_products"]
+
+    def test_meshcentral_by_product(self):
+        r = classify_host(host(svc(8086, product="MeshCentral")))
+        assert r["rmm_detected"] is True
+
+
+class TestDomainCsvSourcing:
+    """FP-0011 matches domain rows, so the IPs worth checking are the ones
+    those rows resolve to. dea_domains_probed.csv holds 330k rows resolving to
+    ~31.7k unique IPs -- roughly 8.8h at Shodan's ~1 req/s, so runs must be
+    budgeted and incremental rather than exhaustive.
+    """
+
+    def _csv(self, tmp_path, rows):
+        import csv
+        p = tmp_path / "domains.csv"
+        with open(p, "w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=["domain", "a_record", "priority"])
+            w.writeheader()
+            for r in rows:
+                w.writerow(r)
+        return str(p)
+
+    def test_extracts_unique_valid_ips(self, tmp_path):
+        from enrich_rmm_exposure import load_ips_from_csv
+        src = self._csv(tmp_path, [
+            {"domain": "a.example", "a_record": "203.0.113.1", "priority": "high"},
+            {"domain": "b.example", "a_record": "203.0.113.2", "priority": "low"},
+            {"domain": "c.example", "a_record": "203.0.113.1", "priority": "high"},
+            {"domain": "d.example", "a_record": "", "priority": "low"},
+            {"domain": "e.example", "a_record": "not-an-ip", "priority": "low"},
+        ])
+        ips = load_ips_from_csv(src, "a_record")
+        assert ips == ["203.0.113.1", "203.0.113.2"]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from enrich_rmm_exposure import load_ips_from_csv
+        assert load_ips_from_csv(str(tmp_path / "nope.csv"), "a_record") == []
+
+    def test_missing_column_returns_empty_not_error(self, tmp_path):
+        from enrich_rmm_exposure import load_ips_from_csv
+        src = self._csv(tmp_path, [{"domain": "a.example", "a_record": "203.0.113.1", "priority": "x"}])
+        assert load_ips_from_csv(src, "no_such_column") == []


### PR DESCRIPTION
Three changes, two of them prompted by passive DNS on `23.227.173.144`.

## 1 · Favicon sweeps close a real gap

The ASN sweep searched only `http.title`, while host lookups matched titles **and** favicon hashes. A retitled device inside a swept ASN was invisible to the sweep but would have been caught by a direct lookup. Retitling a web UI is trivial; replacing the stock favicon is not — so the title-only sweep was the weaker half.

Shodan can't OR multiple values for `http.favicon.hash` the way it can for `http.title`, so each hash needs its own query:

```
asn:AS29802 http.title:"apache guacamole","blikvm","glkvm","guacamole","jetkvm","nanokvm","pi-kvm","pikvm","tinypilot"
asn:AS29802 http.favicon.hash:-1261329937      # JetKVM
asn:AS29802 http.favicon.hash:-1040945478      # PiKVM
asn:AS29802 http.favicon.hash:-996415781       # TinyPilot
asn:AS29802 http.favicon.hash:-692926325       # PiKVM (alt)
asn:AS29802 http.favicon.hash:-186012304       # GLKVM
asn:AS29802 http.favicon.hash:1323732765       # NanoKVM
```

7 searches per ASN instead of 1 — still far cheaper than a lookup per address in the range.

## 2 · MeshCentral

Passive DNS for `23.227.173.144` showed `mesh.<domain>` beside `rust.<domain>` — MeshCentral running next to RustDesk. MeshCentral is a self-hosted RMM and was missing entirely. It has no fixed port worth matching, so it's identified by title and banner, which required the RMM matcher to consider `http.title` at all — it previously looked only at ports and product banners.

**That same passive DNS argues the 23.227.173.144 finding is benign.** The host serves `search`, `mail`, `cloud`, `meet`, `chat`, `baserow`, `containers`, `workflow` under one domain — a self-hosted homelab, not laptop-farm infrastructure. Useful reminder that ASN-wide sweeps in large commercial hosts mostly surface other people's side projects.

## 3 · Targeting the domain set

FP-0011 matches **domain rows**, but the enrichment only ever looked up a 143-entry campaign IP list — so the fingerprint had almost nothing to match against. `--domain-csv` now sources IPs from a domain CSV column (default `a_record`).

**Measured cost:** 145 host lookups + 15 searches consumed 99 query credits — all attributable to the searches. `api.host()` does not bill query credits. So the constraint is wall clock at ~1 req/s, not budget.

`dea_domains_probed.csv` resolves to **31,700 unique IPs** ≈ 8.8h serially, so the CI step takes a bounded 1,000-IP slice per run and the 30-day cache carries progress forward. Full coverage in roughly a month, at zero credit cost.

| Candidate | Unique IPs | Decision |
|---|---|---|
| `dea_domains_probed.csv` | 31,700 | **chosen** — what FP-0011 matches |
| `vpn_relay_ips.csv` | 58,805 | rejected — VPN exits; inbound services belong to the provider, not a worker behind the tunnel |
| `triage_candidates.csv` | 0 | unusable — no `a_record` column |

## Verification

- [x] 8 new tests; **796 pass**
- [x] Sweep covers every known favicon hash (asserted by test)
- [x] No `OR`/parens in any generated query
- [x] Workflow YAML parses; step timeout raised 15 → 20 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)
