### PR TITLE
feat(rmm): incremental ledger, throttling, and multi-source sweeps

### DIFF
--- a/.github/workflows/update_intelligence.yml
+++ b/.github/workflows/update_intelligence.yml
@@ -293,7 +293,7 @@ jobs:
             # the limit here is wall clock at ~1 req/s, not cost. The domain set
             # resolves to ~31.7k unique IPs; a bounded slice runs each day and
             # the 30-day cache carries progress forward.
-            python scripts/enrich_rmm_exposure.py               --ip-list data/known_campaign_ips.txt               --domain-csv data/dea_domains_probed.csv               --ip-column a_record               --asn-seed data/kadnap_operator_asns.csv               --output data/rmm_exposure.csv               --annotate data/dea_domains_probed.csv               --budget 1000
+            python scripts/enrich_rmm_exposure.py               --ip-list data/known_campaign_ips.txt               --source data/dea_domains_probed.csv:a_record               --source data/vpn_relay_ips.csv:ip               --asn-seed data/kadnap_operator_asns.csv               --output data/rmm_exposure.csv               --annotate data/dea_domains_probed.csv               --budget 1000
           fi
           cp data/rmm_exposure.csv docs/data/ || true
 

--- a/scripts/enrich_rmm_exposure.py
+++ b/scripts/enrich_rmm_exposure.py
@@ -45,6 +45,7 @@ import json
 import logging
 import os
 import sys
+import time
 from typing import Dict, List, Optional
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -90,6 +91,89 @@ RMM_SIGNATURES: Dict[str, Dict] = {
 # 21118/21119 are RustDesk web-client ports only in some deployments; excluded
 # from the default port match to avoid claiming any high port is RustDesk.
 RUSTDESK_CORE_PORTS = {21115, 21116, 21117}
+
+
+class Throttle:
+    """Paces requests to a minimum interval.
+
+    Shodan Basic allows roughly one request per second. A 143-IP run never hit
+    that ceiling; ~90k will immediately.
+    """
+
+    def __init__(self, min_interval: float = 1.05):
+        self.min_interval = min_interval
+        self._last = None
+
+    def wait(self):
+        # One clock read per call: reading again after sleeping would also
+        # charge the sleep itself against the next interval.
+        now = time.monotonic()
+        if self._last is not None:
+            delta = now - self._last
+            if delta < self.min_interval:
+                pause = self.min_interval - delta
+                time.sleep(pause)
+                now += pause
+        self._last = now
+
+
+def parse_source(spec: str):
+    """Split a "path[:column]" source spec, tolerating Windows drive letters."""
+    head, sep, tail = spec.rpartition(":")
+    if sep and tail and "/" not in tail and "\\" not in tail and len(tail) > 1:
+        return head, tail
+    return spec, "a_record"
+
+
+def load_existing_results(path: str) -> Dict[str, Dict]:
+    """Read the results ledger, keyed by IP. Missing file is simply empty."""
+    out: Dict[str, Dict] = {}
+    if not os.path.exists(path):
+        return out
+    try:
+        with open(path, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                ip = (row.get("ip") or "").strip()
+                if ip:
+                    out[ip] = row
+    except Exception as e:
+        log.warning(f"Could not read existing results {path}: {e}")
+    return out
+
+
+def merge_results(existing: Dict[str, Dict], new: List[Dict]) -> List[Dict]:
+    """Merge new findings into the ledger, newest record per IP winning.
+
+    Rows not revisited this run are preserved untouched -- the ledger only ever
+    grows or refreshes, never loses coverage.
+    """
+    merged = dict(existing)
+    for row in new:
+        ip = (row.get("ip") or "").strip()
+        if ip:
+            merged[ip] = row
+    return [merged[k] for k in sorted(merged)]
+
+
+def filter_unchecked(ips: List[str], existing: Dict[str, Dict], today: str,
+                     max_age_days: int = 30) -> List[str]:
+    """Drop IPs already checked within max_age_days.
+
+    This is what makes progress independent of the SQLite cache: the ledger
+    itself records what has been covered, so cache expiry cannot silently
+    restart the sweep from the beginning.
+    """
+    from datetime import date
+    def _stale(rec):
+        d = (rec.get("checked_date") or "").strip()
+        if not d:
+            return True
+        try:
+            a = date.fromisoformat(today) - date.fromisoformat(d)
+        except ValueError:
+            return True
+        return a.days >= max_age_days
+    return [ip for ip in ips if ip not in existing or _stale(existing[ip])]
 
 
 def _iter_services(host: Dict):
@@ -252,7 +336,7 @@ def asn_sweep_queries(asn: str) -> List[str]:
     return [f"asn:{asn} {kvm_search_query()}"] + [f"asn:{asn} {q}" for q in kvm_favicon_queries()]
 
 
-def lookup_host(api, ip: str, cache=None):
+def lookup_host(api, ip: str, cache=None, retries: int = 3, throttle=None):
     """Shodan host lookup, cached.
 
     Returns (record, used_api). record is None when the IP is unknown to
@@ -265,16 +349,28 @@ def lookup_host(api, ip: str, cache=None):
         hit = cache.get(key, max_age_days=30)
         if hit is not None:
             return hit, False
-    try:
-        # minify=False: the per-service banner detail (product, http.title,
-        # favicon) is exactly what the signatures match on.
-        rec = api.host(ip, minify=False)
-    except Exception as e:
-        msg = str(e)
-        if "No information available" in msg:
-            log.debug(f"{ip}: not in Shodan")
-            return None, True
-        log.warning(f"{ip}: lookup failed: {type(e).__name__}: {msg}")
+    rec = None
+    for attempt in range(1, retries + 1):
+        if throttle is not None:
+            throttle.wait()
+        try:
+            # minify=False: the per-service banner detail (product, http.title,
+            # favicon) is exactly what the signatures match on.
+            rec = api.host(ip, minify=False)
+            break
+        except Exception as e:
+            msg = str(e)
+            if "No information available" in msg:
+                # A genuine "not in Shodan" is an answer, not a failure; do not
+                # spend retries on it.
+                log.debug(f"{ip}: not in Shodan")
+                return None, True
+            if attempt >= retries:
+                log.warning(f"{ip}: lookup failed after {retries} attempts: "
+                            f"{type(e).__name__}: {msg}")
+                return None, True
+            time.sleep(min(2 ** attempt, 30))
+    if rec is None:
         return None, True
     if cache is not None:
         try:
@@ -352,11 +448,16 @@ def main():
                         help="Maximum Shodan calls this run")
     parser.add_argument("--skip-asn-sweep", action="store_true",
                         help="Host lookups only; makes no search queries")
+    parser.add_argument("--source", action="append", default=[],
+                        metavar="PATH[:COLUMN]",
+                        help="CSV to source IPs from, repeatable. Column defaults "
+                             "to a_record, e.g. data/vpn_relay_ips.csv:ip")
     parser.add_argument("--domain-csv", default=None,
-                        help="Domain CSV to source IPs from (uses --ip-column). "
-                             "Processed after --ip-list, budget permitting; the "
-                             "30-day cache makes successive runs pick up where "
-                             "the last left off.")
+                        help="Deprecated alias for a single --source")
+    parser.add_argument("--recheck-days", type=int, default=30,
+                        help="Skip IPs already checked within this many days")
+    parser.add_argument("--checkpoint-every", type=int, default=100,
+                        help="Flush the results ledger every N lookups")
     parser.add_argument("--annotate", default=None,
                         help="Domain CSV to join findings onto (adds columns in place)")
     parser.add_argument("--ip-column", default="a_record",
@@ -389,12 +490,54 @@ def main():
     results: List[Dict] = []
     spent = 0
 
-    # --- 1. Known campaign IPs -------------------------------------------
-    for ip in load_ip_list(args.ip_list):
+    # The results file is the progress ledger. Basing resumption on it rather
+    # than on the SQLite cache means a cache expiry or loss cannot silently
+    # restart the sweep from the beginning.
+    existing = load_existing_results(args.output)
+    log.info(f"Ledger: {len(existing)} IPs already recorded in {args.output}")
+
+    throttle = Throttle()
+    results: List[Dict] = []
+
+    def checkpoint():
+        rows = merge_results(existing, results)
+        os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+        with open(args.output, "w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=FIELDS, extrasaction="ignore")
+            w.writeheader()
+            w.writerows(rows)
+        return len(rows)
+
+    # --- Assemble the work list ------------------------------------------
+    sources = [(args.ip_list, None)]
+    if args.domain_csv:
+        sources.append((args.domain_csv, args.ip_column))
+    for spec in args.source:
+        sources.append(parse_source(spec))
+
+    work: List[tuple] = []
+    seen = set()
+    for path, column in sources:
+        ips = load_ip_list(path) if column is None else load_ips_from_csv(path, column)
+        label = os.path.basename(path)
+        for ip in ips:
+            if ip not in seen:
+                seen.add(ip)
+                work.append((ip, label))
+
+    todo = filter_unchecked([ip for ip, _ in work], existing, today, args.recheck_days)
+    todo_set = set(todo)
+    label_of = dict(work)
+    log.info(f"{len(work)} unique IPs across {len(sources)} source(s); "
+             f"{len(todo)} need checking, {len(work) - len(todo)} already fresh")
+
+    # --- Look up ----------------------------------------------------------
+    for i, ip in enumerate(todo, 1):
         if spent >= args.budget:
-            log.warning(f"Budget of {args.budget} reached; {ip} onwards not checked")
+            log.info(f"Budget of {args.budget} reached; {len(todo) - i + 1} IPs "
+                     f"deferred to the next run (the ledger carries progress)")
             break
-        rec, used_api = lookup_host(api, ip, cache)
+        rec, used_api = lookup_host(api, ip, cache, throttle=throttle)
         if used_api:
             spent += 1
         if rec is None:
@@ -404,36 +547,16 @@ def main():
             log.info(f"  {ip}: {found['exposure_evidence']}")
         results.append({
             "ip": ip,
-            "source": os.path.basename(args.ip_list),
+            "source": label_of.get(ip, ""),
             "asn": rec.get("asn", ""),
             "checked_date": today,
             **found,
         })
+        if args.checkpoint_every and len(results) % args.checkpoint_every == 0:
+            n = checkpoint()
+            log.info(f"  checkpoint: {n} rows in ledger ({spent} lookups this run)")
 
-    # --- 1b. IPs from a domain CSV ---------------------------------------
-    if args.domain_csv:
-        for ip in load_ips_from_csv(args.domain_csv, args.ip_column):
-            if spent >= args.budget:
-                log.info(f"Budget of {args.budget} reached; remaining IPs deferred "
-                         f"to the next run (cache carries progress forward)")
-                break
-            rec, used_api = lookup_host(api, ip, cache)
-            if used_api:
-                spent += 1
-            if rec is None:
-                continue
-            found = classify_host(rec)
-            if found["kvm_detected"] or found["rmm_detected"]:
-                log.info(f"  {ip}: {found['exposure_evidence']}")
-            results.append({
-                "ip": ip,
-                "source": os.path.basename(args.domain_csv),
-                "asn": rec.get("asn", ""),
-                "checked_date": today,
-                **found,
-            })
-
-    # --- 2. Operator ASN sweep -------------------------------------------
+    # --- Operator ASN sweep ------------------------------------------------
     if not args.skip_asn_sweep:
         for row in load_asn_seed(args.asn_seed):
             if spent >= args.budget:
@@ -445,6 +568,7 @@ def main():
             for q in asn_sweep_queries(asn):
                 if spent >= args.budget:
                     break
+                throttle.wait()
                 try:
                     res = api.search(q, limit=100)
                     spent += 1
@@ -464,18 +588,19 @@ def main():
                     **found,
                 })
 
-    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
-    with open(args.output, "w", newline="", encoding="utf-8") as f:
-        w = csv.DictWriter(f, fieldnames=FIELDS)
-        w.writeheader()
-        w.writerows(results)
+    # Write through the ledger merge, never the raw run results: writing
+    # `results` alone would discard every IP checked on previous runs.
+    total = checkpoint()
 
     if args.annotate:
-        by_ip = {r["ip"]: r for r in results if r.get("ip")}
-        annotate_csv(args.annotate, args.annotate, by_ip, args.ip_column)
+        # Annotate from the whole ledger, not just this run, so domains whose
+        # IPs were checked days ago keep their columns.
+        annotate_csv(args.annotate, args.annotate,
+                     load_existing_results(args.output), args.ip_column)
 
-    hits = [r for r in results if r["kvm_detected"] or r["rmm_detected"]]
-    log.info(f"Wrote {len(results)} rows to {args.output} ({len(hits)} with exposure)")
+    hits = [r for r in results if r.get("kvm_detected") or r.get("rmm_detected")]
+    log.info(f"Ledger holds {total} IPs in {args.output}; "
+             f"{len(results)} checked this run, {len(hits)} with exposure")
     log.info(f"Shodan calls used: {spent}")
     return 0
 

--- a/tests/test_rmm_exposure.py
+++ b/tests/test_rmm_exposure.py
@@ -310,3 +310,124 @@ class TestDomainCsvSourcing:
         from enrich_rmm_exposure import load_ips_from_csv
         src = self._csv(tmp_path, [{"domain": "a.example", "a_record": "203.0.113.1", "priority": "x"}])
         assert load_ips_from_csv(src, "no_such_column") == []
+
+
+class TestResultsLedger:
+    """The results CSV is the progress ledger, not the SQLite cache.
+
+    The cache expires at 30 days; if progress depended on it, day 31 would
+    silently restart the sweep from the top. Recording checked_date per IP and
+    skipping recently-checked addresses makes progress survive cache loss.
+    """
+
+    def _write(self, path, rows):
+        import csv
+        from enrich_rmm_exposure import FIELDS
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=FIELDS, extrasaction="ignore")
+            w.writeheader()
+            for r in rows:
+                w.writerow(r)
+
+    def test_load_existing_returns_ip_keyed_map(self, tmp_path):
+        from enrich_rmm_exposure import load_existing_results
+        p = str(tmp_path / "r.csv")
+        self._write(p, [
+            {"ip": "1.1.1.1", "checked_date": "2026-08-20", "kvm_detected": "False"},
+            {"ip": "2.2.2.2", "checked_date": "2026-08-21", "kvm_detected": "True"},
+        ])
+        got = load_existing_results(p)
+        assert set(got) == {"1.1.1.1", "2.2.2.2"}
+        assert got["2.2.2.2"]["kvm_detected"] == "True"
+
+    def test_missing_file_is_empty_not_error(self, tmp_path):
+        from enrich_rmm_exposure import load_existing_results
+        assert load_existing_results(str(tmp_path / "nope.csv")) == {}
+
+    def test_merge_dedupes_by_ip_newest_wins(self):
+        from enrich_rmm_exposure import merge_results
+        existing = {"1.1.1.1": {"ip": "1.1.1.1", "checked_date": "2026-08-01",
+                                "rmm_products": "", "rmm_detected": "False"}}
+        new = [{"ip": "1.1.1.1", "checked_date": "2026-08-23",
+                "rmm_products": "RustDesk", "rmm_detected": "True"},
+               {"ip": "9.9.9.9", "checked_date": "2026-08-23",
+                "rmm_products": "", "rmm_detected": "False"}]
+        merged = merge_results(existing, new)
+        assert len(merged) == 2
+        by_ip = {r["ip"]: r for r in merged}
+        assert by_ip["1.1.1.1"]["rmm_products"] == "RustDesk", "newer record must win"
+        assert by_ip["1.1.1.1"]["checked_date"] == "2026-08-23"
+
+    def test_merge_never_loses_prior_rows(self):
+        from enrich_rmm_exposure import merge_results
+        existing = {f"10.0.0.{i}": {"ip": f"10.0.0.{i}", "checked_date": "2026-08-01"}
+                    for i in range(1, 51)}
+        merged = merge_results(existing, [{"ip": "10.0.0.1", "checked_date": "2026-08-23"}])
+        assert len(merged) == 50, "appending must not drop untouched rows"
+
+    def test_recently_checked_ips_are_skipped(self):
+        from enrich_rmm_exposure import filter_unchecked
+        existing = {"1.1.1.1": {"ip": "1.1.1.1", "checked_date": "2026-08-23"},
+                    "2.2.2.2": {"ip": "2.2.2.2", "checked_date": "2026-01-01"}}
+        todo = filter_unchecked(["1.1.1.1", "2.2.2.2", "3.3.3.3"], existing,
+                                today="2026-08-23", max_age_days=30)
+        assert todo == ["2.2.2.2", "3.3.3.3"], "fresh skipped, stale and new kept"
+
+    def test_blank_checked_date_is_treated_as_stale(self):
+        from enrich_rmm_exposure import filter_unchecked
+        existing = {"1.1.1.1": {"ip": "1.1.1.1", "checked_date": ""}}
+        assert filter_unchecked(["1.1.1.1"], existing, today="2026-08-23") == ["1.1.1.1"]
+
+
+class TestRateLimiting:
+    """~31.7k lookups at Shodan's ~1 req/s needs pacing and resilience; a
+    143-IP test was too small to expose either need."""
+
+    def test_throttle_sleeps_to_maintain_interval(self):
+        from unittest.mock import patch
+        from enrich_rmm_exposure import Throttle
+        slept = []
+        with patch("enrich_rmm_exposure.time.sleep", side_effect=slept.append):
+            with patch("enrich_rmm_exposure.time.monotonic", side_effect=[100.0, 100.2, 100.2]):
+                t = Throttle(min_interval=1.0)
+                t.wait()   # first call: no wait
+                t.wait()   # 0.2s later: must sleep ~0.8s
+        assert slept and 0.7 < slept[0] <= 1.0, slept
+
+    def test_lookup_retries_then_succeeds(self):
+        from unittest.mock import MagicMock, patch
+        from enrich_rmm_exposure import lookup_host
+        api = MagicMock()
+        api.host.side_effect = [Exception("rate limit"), {"ip_str": "1.2.3.4", "data": []}]
+        with patch("enrich_rmm_exposure.time.sleep"):
+            rec, used = lookup_host(api, "1.2.3.4", cache=None, retries=2)
+        assert rec is not None and used is True
+        assert api.host.call_count == 2
+
+    def test_unknown_ip_is_not_retried(self):
+        from unittest.mock import MagicMock, patch
+        from enrich_rmm_exposure import lookup_host
+        api = MagicMock()
+        api.host.side_effect = Exception("No information available for that IP.")
+        with patch("enrich_rmm_exposure.time.sleep"):
+            rec, used = lookup_host(api, "1.2.3.4", cache=None, retries=3)
+        assert rec is None
+        assert api.host.call_count == 1, "a genuine 'not found' must not burn retries"
+
+
+class TestMultipleSources:
+    """Both the domain set and the VPN relay set are swept, and they key their
+    IPs in differently-named columns (a_record vs ip)."""
+
+    def test_parses_path_and_column(self):
+        from enrich_rmm_exposure import parse_source
+        assert parse_source("data/x.csv:ip") == ("data/x.csv", "ip")
+
+    def test_defaults_column_when_omitted(self):
+        from enrich_rmm_exposure import parse_source
+        assert parse_source("data/x.csv") == ("data/x.csv", "a_record")
+
+    def test_windows_drive_letter_is_not_split(self):
+        from enrich_rmm_exposure import parse_source
+        assert parse_source(r"C:\data\x.csv:ip") == (r"C:\data\x.csv", "ip")
+        assert parse_source(r"C:\data\x.csv") == (r"C:\data\x.csv", "a_record")


### PR DESCRIPTION
Prepares the sweep for **~90,500 IPs** — `dea_domains_probed.csv` (31,700) plus `vpn_relay_ips.csv` (58,805) — roughly **26 hours** at Shodan's ~1 req/s. Three of these four changes are prerequisites for a run that long.

## 1 · The results file becomes the progress ledger

Runs previously overwrote the output and relied on the SQLite cache to avoid repeat work. **That cache expires at 30 days**, so on day 31 the sweep would silently restart from the top with nothing to indicate it had.

The output CSV is now read back, merged by IP (newest record wins), and rewritten. `filter_unchecked()` skips IPs whose `checked_date` falls inside `--recheck-days`. Progress survives cache loss entirely.

**Two clobbering bugs surfaced while wiring this:**

- The final write still emitted raw run results, which would have **discarded every previously-recorded IP** on a resumed run
- `--annotate` joined only *this run's* findings, so domains whose IPs were checked days earlier silently lost their columns

Both now go through the merged ledger. Verified:

```
run 1 -> ledger 6 rows
run 2 -> "6 already fresh", checks 2 new -> ledger 8 rows
```

## 2 · Rate limiting and retry

There was neither. Shodan Basic allows ~1 req/s; a 143-IP test never approached it, 90k hits it immediately. `Throttle` paces requests; lookups retry with exponential backoff. A genuine `No information available` is treated as an *answer*, not a failure, so it doesn't burn retries.

## 3 · Checkpointing

Results were written once at the end — a crash at hour 25 of 26 lost everything. The ledger now flushes every `--checkpoint-every` lookups (default 100).

## 4 · Multiple sources

`--source PATH[:COLUMN]` is repeatable, so both sets can be swept despite keying IPs in differently-named columns (`a_record` vs `ip`). `parse_source` tolerates Windows drive letters.

**On including `vpn_relay_ips.csv`:** I previously argued against it because VPN exits are provider infrastructure. That holds for datacentre gateways but **not** for the residential-proxy providers in the same dataset — Urban VPN, Hola, Bright Data — where the exit *is* an end-user device and exposed remote access is meaningful. Included, with that distinction worth remembering when reading hits.

## Verification

- [x] 12 new tests; **808 pass**
- [x] Resumption verified end-to-end against the live API
- [x] Ledger merge never drops untouched rows (asserted)
- [x] Workflow YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
