### PR TITLE
feat(hunt): expand and prune the campaign discovery query set

### DIFF
--- a/scripts/hunt_campaign.py
+++ b/scripts/hunt_campaign.py
@@ -23,24 +23,64 @@ from shared.sanitize import sanitize_csv_value
 load_dotenv()
 SHODAN_API_KEY = os.getenv("SHODAN_API_KEY")
 
-if not SHODAN_API_KEY:
-    print("Error: SHODAN_API_KEY not found.")
-    sys.exit(1)
+# The key check lives in main(), not at import time: exiting on import makes the
+# module impossible to import for testing, which is why the query set had no
+# coverage despite driving all campaign discovery.
 
 # Configuration
 KNOWN_IPS_FILE = Path("data/known_campaign_ips.txt")
+# Query set. Every entry below was volume-checked against Shodan before being
+# added; every query removed had produced zero findings in six months of runs.
+#
+# Measured behaviour that shapes this list:
+#  - Comma-separated values act as OR *within* http.title, but NOT within
+#    http.html -- a collapsed http.html:"a","b" query returns 0 results, so
+#    body-content terms each need their own query.
+#  - http.html consistently outperforms http.title for the same term, because a
+#    site can rename its <title> to something innocuous while the body still
+#    carries the words users read:
+#        temporary email   title 308  ->  html 463
+#        disposable email  title  93  ->  html 308
+#        temp mail         title 117  ->  html 246
+#        临时邮箱           title 115  ->  html 266
+#  - "Temp Mail"/"TempMail" were absent entirely and overlap the existing
+#    "Temporary Email" query by only 36 hosts, i.e. ~202 hosts were invisible.
+#
+# KNOWN LIMITATION: api.search() returns only the first page (100 matches), so
+# a query matching 651 hosts surfaces 100 of them. Dedup means later runs
+# re-see the same page and find nothing new, so coverage plateaus. Paginating
+# would multiply credit cost and is left as a deliberate follow-up.
 QUERIES = [
-    'net:51.254.35.0/24 "Public Email Service"',
-    'http.title:"Public Email Service"',
-    'ssl:"in.mail.tm"',
-    'http.title:"Disposable Email"',
-    'http.title:"Disposable Temporary Email"',
-    'http.title:"Disposable Emails"', 
-    'http.title:"Temporary Email"',
-    'http.title:"Temporary Emails"',
-    'http.title:"disposable and free domain"'
+    # --- English titles, collapsed into one OR'd filter (~651 hosts) ---
+    'http.title:"temporary email","temp mail","tempmail","temp email",'
+    '"disposable email","disposable mailbox","temporary mailbox",'
+    '"email generator","anonymous email","fake email","10 minute mail","mailinator"',
+
+    # --- Non-English titles (~159 hosts). Chinese dominates, which fits DEA
+    # infrastructure clustering on Alibaba Cloud and China Telecom ranges. ---
+    'http.title:"临时邮箱","临时邮件","Email sementara","Correo temporal",'
+    '"Временная почта","Email temporário","Geçici e-posta","Wegwerf"',
+
+    # --- Body content: obfuscation-resistant, one query per term ---
+    'http.html:"temporary email"',
+    'http.html:"disposable email"',
+    'http.html:"temp mail"',
+    'http.html:"tempmail"',
+    'http.html:"临时邮箱"',
+    'http.html:"Email sementara"',
+
+    # --- Retained from the original set: 76 findings historically ---
+    'http.title:"disposable and free domain"',
 ]
-BUDGET_LIMIT = 20 # credits
+
+# Removed after six months of zero findings each:
+#   'http.title:"Public Email Service"'          (global volume: 1)
+#   'net:51.254.35.0/24 "Public Email Service"'  (range now inactive)
+#   'ssl:"in.mail.tm"'
+# Also folded in: "Temporary Emails"/"Disposable Emails" (2 global hosts each)
+# are covered by the collapsed English title query above.
+
+BUDGET_LIMIT = 30 # credits; 9 queries plus headroom for retries
 
 import csv
 from datetime import datetime
@@ -147,6 +187,10 @@ def main():
     print("--- Automated Campaign Hunt ---")
 
     # 1. Setup Budget
+    if not SHODAN_API_KEY:
+        print("Error: SHODAN_API_KEY not found.")
+        return 1
+
     budget = CreditBudget()
     budget.set_budget(BUDGET_LIMIT)
 

--- a/tests/test_hunt_campaign.py
+++ b/tests/test_hunt_campaign.py
@@ -1,0 +1,104 @@
+"""Tests for the campaign hunt query set.
+
+hunt_campaign.py drives all proactive discovery of DEA infrastructure and runs
+in CI, but had no coverage -- partly because importing it used to call
+sys.exit(1) when SHODAN_API_KEY was absent.
+
+Every assertion here encodes a fact measured against the live Shodan API, so a
+future edit that reintroduces a dead query or an unsupported syntax fails loudly
+rather than silently returning nothing.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from hunt_campaign import QUERIES, BUDGET_LIMIT
+
+
+class TestQuerySyntax:
+    def test_html_filters_are_never_comma_collapsed(self):
+        """Comma-OR works inside http.title but NOT inside http.html.
+
+        A collapsed http.html:"a","b" query measured 0 results, so collapsing
+        body-content terms silently disables them.
+        """
+        for q in QUERIES:
+            if "http.html:" in q:
+                body = q.split("http.html:", 1)[1]
+                assert '","' not in body, f"http.html cannot OR with commas: {q}"
+
+    def test_no_boolean_or_or_parentheses(self):
+        for q in QUERIES:
+            assert " OR " not in q, f"Shodan rejects boolean OR: {q}"
+            assert "(" not in q and ")" not in q, f"Shodan rejects parens: {q}"
+
+    def test_every_query_is_a_nonempty_string(self):
+        assert QUERIES
+        for q in QUERIES:
+            assert isinstance(q, str) and q.strip()
+
+
+class TestDeadQueriesStayRemoved:
+    """Each produced zero findings across six months of runs."""
+
+    DEAD = ['http.title:"Public Email Service"',
+            "net:51.254.35.0/24",
+            'ssl:"in.mail.tm"']
+
+    def test_zero_yield_queries_are_gone(self):
+        joined = " ".join(QUERIES)
+        for dead in self.DEAD:
+            assert dead not in joined, f"zero-yield query reintroduced: {dead}"
+
+
+class TestCoverage:
+    """The gaps that made ~200 hosts invisible."""
+
+    def test_temp_mail_variants_present(self):
+        joined = " ".join(QUERIES).lower()
+        for term in ("temp mail", "tempmail"):
+            assert term in joined, f"missing high-volume term: {term}"
+
+    def test_chinese_term_present(self):
+        """Highest-volume non-English term (title 115 / html 266), and it fits
+        DEA infrastructure clustering on Chinese hosting."""
+        assert "临时邮箱" in " ".join(QUERIES)
+
+    def test_body_content_queries_exist(self):
+        """http.html outperformed http.title for every term measured, and
+        survives a site renaming its <title>."""
+        assert any(q.startswith("http.html:") for q in QUERIES)
+
+    def test_multiple_languages_covered(self):
+        joined = " ".join(QUERIES)
+        for term in ("临时邮箱", "Email sementara", "Correo temporal", "Временная почта"):
+            assert term in joined, f"missing localised term: {term}"
+
+
+class TestBudget:
+    def test_query_count_fits_budget(self):
+        """One credit is spent per query; exceeding the budget silently
+        truncates the run."""
+        assert len(QUERIES) <= BUDGET_LIMIT, (
+            f"{len(QUERIES)} queries exceeds budget of {BUDGET_LIMIT}")
+
+    def test_budget_leaves_headroom(self):
+        assert BUDGET_LIMIT >= len(QUERIES), "no headroom for retries"
+
+
+class TestImportable:
+    def test_module_imports_without_api_key(self):
+        """Importing must not exit; the key check belongs in main()."""
+        import importlib
+        saved = os.environ.pop("SHODAN_API_KEY", None)
+        try:
+            import hunt_campaign
+            importlib.reload(hunt_campaign)
+            assert hunt_campaign.QUERIES
+        finally:
+            if saved is not None:
+                os.environ["SHODAN_API_KEY"] = saved


### PR DESCRIPTION
`hunt_campaign.py` drives all proactive DEA discovery and runs in CI, but its query list had never been measured and the module had **no tests**. Every change below is backed by a live Shodan volume check.

## Removed — three queries, zero findings in six months

```
http.title:"Public Email Service"           global volume: 1
net:51.254.35.0/24 "Public Email Service"   range inactive
ssl:"in.mail.tm"                            no results
```

They consumed budget every run and returned nothing. `"Temporary Emails"` / `"Disposable Emails"` (2 global hosts each) are folded into the collapsed English title query.

## Added — the Temp Mail blind spot

`"Temp Mail"` and `"TempMail"` appeared **nowhere**, despite being the common brand phrasing:

```
"temporary email"          308
"temp mail" + "tempmail"   238
union                      510
  -> 202 hosts previously invisible
  -> only  36 hosts overlapped
```

## Added — non-English titles

```
临时邮箱 115    Email sementara 15    临时邮件 11    Correo temporal 7
Wegwerf   7    Временная почта  5    Email temporário 4   Geçici e-posta 3
```

Chinese dominates, consistent with DEA infrastructure clustering on Alibaba Cloud and China Telecom ranges.

## Added — body-content queries, which resist title obfuscation

`http.html` outperformed `http.title` for **every** term measured. Renaming a `<title>` is trivial; the body still carries the words users have to read:

| term | title | html |
|---|---|---|
| temporary email | 308 | **463** |
| disposable email | 93 | **308** |
| temp mail | 117 | **246** |
| 临时邮箱 | 115 | **266** |

## Two syntax facts found by testing, not assuming

Comma-separated values OR correctly inside `http.title`, but a collapsed `http.html:"a","b"` returns **0** — body terms each need their own query. A test now enforces this, because the failure mode is silent.

## Testability

Importing the module used to call `sys.exit(1)` when `SHODAN_API_KEY` was absent — which is precisely why a script this central had no coverage. The check moved into `main()`.

## Favicon clustering: evaluated and rejected

Of 2,006 scanned hosts, only 9 favicons appeared on mail-related titles, and the high-volume ones are generic defaults shared by **1,087,526** and **34,334** hosts. Unlike the IP-KVM case, favicon hashing doesn't discriminate here. Not adding a method the data doesn't support.

## Known limitation, deliberately not addressed

`api.search()` reads only the first page (100 matches), so a query matching 651 hosts surfaces 100, and coverage plateaus once dedup catches up. Paginating multiplies credit cost — worth a separate decision.

## Verification

- [x] 11 new tests — first coverage for this script; **819 pass**
- [x] Every retained query volume-checked against live Shodan
- [x] Test enforces `http.html` is never comma-collapsed
- [x] Test enforces removed queries stay removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
