### PR TITLE
docs: document remote-access detection and refresh stale facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - [Data Dictionary](#data-dictionary)
 - [Responsible Use & Security](#responsible-use--security)
 - [Contributing](#contributing)
+- [Documentation](#documentation)
 - [Acknowledgments](#acknowledgments)
 - [License](#license)
 
@@ -49,10 +50,11 @@
 | **Automated Pipeline** | Daily GitHub Actions workflow with 10-shard parallel processing, artifact passing, and auto-commit to GitHub Pages |
 | **AI-Powered Analysis** | Multi-model LLM chain (Claude Sonnet 4.5 / Gemini 3 Pro / GPT-4o) with automatic fallback, SQLite caching, and cost tracking |
 | **Infrastructure Clustering** | Groups domains by shared MX hosts, MX IPs, web hosting IPs, and registrar+NS — with confidence scoring that penalizes known shared providers |
-| **Fingerprint Detection** | 9 YAML-driven fingerprint rules with confidence modifiers, entity screening boosts, and FLAME threat-path mapping |
+| **Fingerprint Detection** | 11 YAML-driven fingerprint rules with confidence modifiers, entity screening boosts, and FLAME threat-path mapping |
 | **FLAME Integration** | Maps clusters to [FLAME](https://github.com/elchacal801/flame-fraud) fraud threat paths with evidence package generation |
 | **STIX 2.1 Export** | Full STIX bundle generation for direct ingestion into OpenCTI, MISP, or any CTI platform |
 | **Shadow AI Scanner** | Detects exposed OpenClaw/Moltbot/Gateway AI agents on port 18789 via Shodan with STIX + Sigma rule export |
+| **Remote Access Detection** | Finds internet-exposed IP-KVM hardware (PiKVM, TinyPilot, JetKVM, NanoKVM, GLKVM) and RMM tooling (RustDesk, AnyDesk, TeamViewer, ScreenConnect, MeshCentral) — the laptop-farm pattern behind DPRK IT-worker operations, mapped to MITRE T1219.003 |
 | **Investigation Dashboard** | React 19 + Vite 7 + Tailwind CSS 4 frontend with Sigma.js graph visualization, TanStack Table, and fuzzy search |
 | **Proactive Discovery** | SEADS ad scanning, dnstwist permutation generation, Certificate Transparency log streaming, and Shodan campaign hunts |
 | **Entity Screening** | Cross-references domains against GLEIF (corporate registry), OpenSanctions (PEPs/sanctions), and ICIJ OffshoreLeaks |
@@ -312,6 +314,10 @@ For GitHub Actions, add these as **Repository Secrets** in Settings > Secrets an
 ### Running the Pipeline Locally
 
 ```bash
+# 0. Proactive discovery (optional; requires SHODAN_API_KEY)
+python scripts/hunt_campaign.py     # disposable-email infrastructure
+python scripts/hunt_kvm.py          # internet-exposed IP-KVM devices
+
 # 1. Merge and deduplicate source lists
 python scripts/merge_lists_v3b.py --include-stopforumspam
 
@@ -343,6 +349,8 @@ python scripts/ai_classify_web.py --limit 2000 --batch-size 50
 python scripts/ai_briefing.py
 
 # 8. Detection & scoring
+#    Must precede match_fingerprints.py: FP-0011 matches the columns it writes.
+python scripts/enrich_rmm_exposure.py   --ip-list data/known_campaign_ips.txt   --source data/dea_domains_probed.csv:a_record   --source data/vpn_relay_ips.csv:ip   --output data/rmm_exposure.csv   --annotate data/dea_domains_probed.csv   --budget 1000
 python scripts/match_fingerprints.py
 python scripts/build_frontend_data.py
 python scripts/generate_pivots.py --input data/dea_domains_probed.csv
@@ -599,7 +607,7 @@ domain_intel/
 
 ### Daily Data Update (`update_intelligence.yml`)
 
-Runs daily at 11:00 UTC (6:00 AM EST) with manual dispatch support.
+Runs daily at **07:00 UTC** (2:00 AM EST / 12:00 AM MST) with manual dispatch support.
 
 ```mermaid
 graph LR
@@ -636,7 +644,14 @@ pytest
 pytest tests/test_llm_client.py -v
 ```
 
-The test suite covers 37 modules. Key test areas:
+**846 tests across 44 modules**, run automatically on every push and pull
+request by the `Tests` workflow (`.github/workflows/tests.yml`) on Python 3.11.
+
+`pytest.ini` sets `testpaths = tests`, so a bare `pytest` never collects
+`scripts/probe_*.py` — those are interactive capability probes that build live
+API clients at import time.
+
+Key test areas:
 
 | Test Module | Coverage |
 |---|---|
@@ -649,6 +664,10 @@ The test suite covers 37 modules. Key test areas:
 | `test_classify_rules.py` | Web classification rules |
 | `test_typosquat_scoring.py` | Typosquat confidence scoring |
 | `test_pivots.py` | Pivot generation (SOA/SSL selectors) |
+| `test_rmm_exposure.py` | IP-KVM/RMM signature matching, results ledger, throttling |
+| `test_hunt_kvm.py` | IP-KVM discovery queries and Shodan syntax constraints |
+| `test_hunt_campaign.py` | Campaign hunt query set and budget |
+| `test_suite_hygiene.py` | Guards against sys.modules leakage between test modules |
 | `test_gleif.py` | GLEIF corporate entity verification |
 | `test_opensanctions.py` | OpenSanctions PEP/sanctions screening |
 | `test_virustotal.py` | VirusTotal enrichment |
@@ -743,6 +762,16 @@ Contributions are welcome. Please follow these guidelines:
 2. Define `indicators` (required + optional), `confidence_base`, `confidence_modifiers`, and `flame_tp_ids`
 3. Run `python scripts/match_fingerprints.py` to test
 4. Run `python scripts/generate_fp_registry.py` to update the frontend registry
+
+---
+
+## Documentation
+
+| Guide | Covers |
+|---|---|
+| [Remote Access & IP-KVM Detection](docs/remote-access-detection.md) | FP-0011, laptop-farm infrastructure, Shodan query constraints, MITRE T1219.003 |
+| [VPN IP Intelligence Operations](docs/vpn-ip-intel-operations.md) | 20 providers, manual refresh cadence, DPRK scoring, Shodan org discovery |
+| [Detection Logic](docs/detection_logic.md) | Vendor-agnostic SOC detection patterns for DEA abuse |
 
 ---
 

--- a/docs/remote-access-detection.md
+++ b/docs/remote-access-detection.md
@@ -1,0 +1,187 @@
+# Remote Access & IP-KVM Detection
+
+Detection of internet-exposed IP-KVM hardware and remote-management (RMM) tooling, the infrastructure pattern behind DPRK IT-worker laptop farms.
+
+## Why this exists
+
+2026 reporting (Google Cloud Threat Intelligence, Nisos, runZero) describes laptop farms built on **IP-KVM hardware**: a US-based facilitator receives and racks company laptops while the actual worker, in DPRK or China, drives them remotely over KVM. Where KVM hardware is unavailable, **RMM tooling** — AnyDesk, TeamViewer, RustDesk, ScreenConnect, Chrome Remote Desktop — serves as the fallback layer.
+
+An IP-KVM is a hardware dongle on the laptop's USB and HDMI. It presents as keyboard, video and mouse, so **no software runs on the host and EDR sees nothing**. Geolocation, device posture and network checks all pass, because the laptop genuinely is sitting in the US.
+
+MITRE covers the technique as **T1219.003 (Remote Access Hardware)**, with detection strategy **DET0159** naming TinyPilot and PiKVM. DET0159 is host-based — USB enumeration, EDID announcements, mount paths — which an external pipeline cannot observe. This module provides the complementary **network-side** view.
+
+Google Cloud notes these connections originate predominantly from **Astrill VPN** addresses, a population this pipeline already resolves — see [VPN IP Intelligence](vpn-ip-intel-operations.md).
+
+---
+
+## Components
+
+| Component | Role |
+|---|---|
+| `scripts/enrich_rmm_exposure.py` | Classifies known IPs — is this host exposing KVM/RMM? |
+| `scripts/hunt_kvm.py` | Discovers unknown IP-KVM devices proactively via Shodan |
+| `config/fingerprints/FP-0011-remote-access-exposure.yaml` | Scores findings on domain rows |
+| `data/kvm_hardware_identifiers.csv` | Host-side artifacts for the EDR/LogScale side |
+| `data/vpn_seeds/kvm_silentpush_20260824.csv` | 1,878-IP baseline from Silent Push |
+
+The two scripts answer different questions. **Classification** takes IPs you already have and asks what they expose; **discovery** finds hosts you did not know about. Discovery keeps its own baseline (`data/known_kvm_ips.txt` and the Silent Push seed) rather than writing into `known_campaign_ips.txt`, so KVM findings never blur disposable-email campaign attribution.
+
+---
+
+## Signatures
+
+### IP-KVM — HTTP titles and favicon hashes
+
+Favicon hashes matter because a title is trivially customised while the stock favicon usually survives a rebrand. Source: runZero's IP-KVM survey.
+
+| Product | Titles | Favicon hashes |
+|---|---|---|
+| PiKVM | `pikvm`, `pi-kvm` | `-1040945478`, `-692926325` |
+| TinyPilot | `tinypilot` | `-996415781` |
+| JetKVM | `jetkvm` | `-1261329937` |
+| GLKVM | `glkvm` | `-186012304` |
+| NanoKVM | `nanokvm` | `1323732765` |
+| BliKVM | `blikvm` | — |
+| Apache Guacamole | `apache guacamole`, `guacamole` | — |
+
+### RMM — ports and product banners
+
+| Product | Ports | Banner / title |
+|---|---|---|
+| RustDesk | 21115, 21116, 21117 | `rustdesk` |
+| AnyDesk | 7070 | `anydesk` |
+| TeamViewer | 5938 | `teamviewer` |
+| ScreenConnect | 8172 | `screenconnect`, `connectwise` |
+| MeshCentral | — | `meshcentral` |
+| VNC | 5900–5905 | `vnc`, `realvnc`, `tightvnc` |
+| RDP | 3389 | `remote desktop`, `ms-wbt-server` |
+
+MeshCentral was found by passive DNS: a host serving `mesh.<domain>` beside `rust.<domain>`. It has no fixed port worth matching, so it is identified by title and banner only.
+
+---
+
+## Scoring — rarity drives confidence
+
+FP-0011 matches the `kvm_detected` / `rmm_detected` columns written onto domain rows, the same way FP-0010 consumes `proxy_detected` from `enrich_proxy_check.py`.
+
+| Signal | Δ | Reasoning |
+|---|---|---|
+| PiKVM, TinyPilot, JetKVM, NanoKVM, GLKVM, BliKVM | **+30** | dedicated KVM hardware on the public internet is genuinely unusual |
+| Astrill egress | **+25** | remote access *reachable from a VPN egress* is the reported pattern |
+| RustDesk, AnyDesk, TeamViewer, ScreenConnect | +20 | named in reporting, but also ordinary IT tooling |
+| Apache Guacamole | +15 | legitimate enterprise gateway as well |
+| Mullvad egress / proxy detected | +10 | corroboration |
+| **RDP** | **−25** | ubiquitous — must never carry a match alone |
+| **VNC** | **−20** | ubiquitous |
+
+Base confidence 40. The negative modifiers are the important design decision: without them, port 3389 alone would flood the output. In the first production run, 2 of 3 findings were plain RDP.
+
+---
+
+## Running it
+
+### Classification
+
+```bash
+python scripts/enrich_rmm_exposure.py \
+  --ip-list data/known_campaign_ips.txt \
+  --source data/dea_domains_probed.csv:a_record \
+  --source data/vpn_relay_ips.csv:ip \
+  --asn-seed data/kadnap_operator_asns.csv \
+  --output data/rmm_exposure.csv \
+  --annotate data/dea_domains_probed.csv \
+  --budget 1000
+```
+
+`--source PATH[:COLUMN]` is repeatable; the column defaults to `a_record`.
+
+**The output file is the progress ledger, not the cache.** Results are read back, merged by IP with the newest record winning, and rewritten. `--recheck-days` (default 30) skips recently-checked IPs. Progress therefore survives cache expiry or loss — anchoring it to the 30-day SQLite cache would silently restart the sweep on day 31.
+
+Runs are checkpointed every `--checkpoint-every` lookups (default 100), so an interrupted run loses nothing and the next invocation resumes where it stopped.
+
+### Discovery
+
+```bash
+python scripts/hunt_kvm.py --budget 20
+python scripts/hunt_kvm.py --dry-run     # print queries, call nothing
+```
+
+New hosts are appended to `data/kvm_hunt_history.csv` and surfaced as GitHub Actions `::warning::` annotations. **The script always exits 0** — the discovery job has no `continue-on-error`, so a non-zero exit on findings would fail the job and abort the pipeline.
+
+---
+
+## Cost and rate limits
+
+Measured on a Shodan **Basic** plan: 145 host lookups plus 15 searches consumed **99 query credits**, all attributable to the searches.
+
+> `api.host()` does not bill query credits. Searches do.
+
+The binding constraint for classification is therefore wall clock at roughly **1 request/second**, not budget. The combined domain and VPN relay sets hold ~90,500 unique IPs, about 26 hours serially — hence the bounded per-run slice, the request throttle, and retry with exponential backoff. A genuine `No information available` is treated as an answer, not a failure, so it does not consume retries.
+
+---
+
+## Query syntax facts worth knowing
+
+Each of these was found by testing, and each fails **silently** if got wrong.
+
+- **Shodan supports neither boolean `OR` nor parentheses.** An early ASN sweep returned `APIError: The search query was invalid` for all five operator ASNs.
+- **Comma-separated values OR correctly inside `http.title`** — but **not** inside `http.html` or `http.favicon.hash`. A collapsed `http.html:"a","b"` returns **zero results**, silently disabling the query. Body and favicon terms each need their own query.
+- **`http.html` consistently outperforms `http.title`.** A site can rename its `<title>`; the body still carries the words users read.
+
+---
+
+## Discovery query performance
+
+Measured against live Shodan, 2026-08-24:
+
+```
+1397  http.title:"pikvm","pi-kvm","tinypilot","jetkvm","nanokvm","glkvm","blikvm"
+ 664  http.html:"pikvm"
+ 560  ssl:"PiKVM"
+ 479  http.favicon.hash:-1040945478
+ 431  http.html:"nanokvm"
+ 338  http.html:"pikvm" -port:443 -port:80      <- roughly half are off 443/80
+ 100  http.html:"jetkvm"
+  97  http.html:"guacamole" http.title:"Guacamole"
+  70  http.html:"tinypilot"
+```
+
+### Rejected after measuring
+
+| Candidate | Volume | Why not |
+|---|---|---|
+| `ssl.jarm:27d28d28d000…` | 10,439 | A TLS-stack fingerprint shared with ordinary nginx, not a device signature. A test forbids using it unqualified. |
+| `ssl.cert.issuer.CN:"PiKVM"` | 7 | Shodan does not index the certificate organisation, despite 7,531 of 10,000 Silent Push records carrying issuer `O=PiKVM`. |
+| `http.html:"guacamole"` bare | 12,780 | Against just 5 for `http.title:"Apache Guacamole"`. Requiring both narrows to 97, which is reviewable. |
+| Favicon clustering of scanned hosts | — | Of 2,006 hosts, only 9 favicons sat on mail-related titles, and the high-volume ones are generic defaults shared by 1,087,526 and 34,334 hosts. Effective for IP-KVM; not discriminating for DEA. |
+
+---
+
+## Coverage caveat
+
+**Shodan surfaces roughly 600 PiKVM hosts where Silent Push observes 14,000+.**
+
+Shodan is a supplementary channel here, not the primary one. The Silent Push export seeds the baseline so the hunt reports genuinely new hosts rather than re-reporting that population. If IP-KVM visibility matters to an investigation, query a web-crawling source directly rather than relying on this hunt alone.
+
+---
+
+## Interpreting findings
+
+**A hit inside a large shared-hosting ASN is a lead, not an attribution.** A worked example: an Apache Guacamole instance in AS29802 (Hivelocity) initially looked like a finding in a KadNap-attributed ASN. Passive DNS resolved it — the host served `mesh`, `rust`, `search`, `mail`, `cloud`, `meet`, `chat`, `baserow`, `containers` and `workflow` under one domain. That is a self-hosted homelab, not laptop-farm infrastructure.
+
+Two lessons carried into the design: ASN-wide sweeps of large commercial hosts mostly surface other people's side projects, and corroborating signals are weighted above raw detection for exactly this reason.
+
+---
+
+## Host-side identifiers
+
+`data/kvm_hardware_identifiers.csv` records artifacts this pipeline **cannot** query but the EDR and LogScale side can — USB vendor/product IDs, default serials (`CAFEBABE` for PiKVM, `6b65796d696d6570690` for TinyPilot), eight Raspberry Pi MAC OUIs, and `/dev/hidg0`, the write target used by the Scapy ARP-listener C2 documented in laptop-farm reporting.
+
+Every row cites its source.
+
+---
+
+## Related
+
+- [VPN IP Intelligence Operations](vpn-ip-intel-operations.md) — Astrill and Mullvad egress resolution, which supplies FP-0011's strongest corroborating signal
+- [Detection Logic](detection_logic.md) — vendor-agnostic SOC detection patterns

--- a/docs/vpn-ip-intel-operations.md
+++ b/docs/vpn-ip-intel-operations.md
@@ -59,12 +59,26 @@ git add data/vpn_seeds/protonvpn/ && git commit -m "data: refresh ProtonVPN cach
 
 ### Mullvad Exit Probe
 
-Requires an active Mullvad WireGuard connection:
+Requires an active Mullvad WireGuard connection — the SOCKS5 relays are only
+reachable from inside the tunnel.
 
 ```bash
 python scripts/mullvad_exit_probe.py
 git add data/vpn_seeds/mullvad_exit_ips.csv && git commit -m "data: refresh Mullvad exit IPs" && git push
 ```
+
+**Last refreshed: 2026-08-24** — 526 → **550 relays**, 550 unique exit IPs,
+matching every currently active relay with SOCKS5.
+
+Worth knowing before trusting the output: the script **overwrites** the seed
+wholesale at the end of a run, so a tunnel drop mid-probe silently shrinks the
+file. Probe to a temporary path and reconcile against the previous seed before
+replacing it. In the last refresh, 545/550 probed clean, 3 recovered on retry,
+and 2 (`fi-hel-wg-001`, `gb-lon-wg-008`) were retained at their older
+`probe_date` — still active but consistently unreachable via SOCKS5. Keeping
+those rows preserves known-good exit IPs and dates them honestly rather than
+dropping coverage. 27 relays were dropped only after confirming against the API
+that they are no longer active.
 
 ---
 
@@ -72,6 +86,67 @@ git add data/vpn_seeds/mullvad_exit_ips.csv && git commit -m "data: refresh Mull
 
 - **Astrill seed**: obtain from Spur Intelligence, save to `data/vpn_seeds/spur_astrill_YYYY.txt`
 - The script warns when the seed file exceeds **180 days old**
+
+> [!IMPORTANT]
+> The current seed is `spur_astrill_2024.txt` — roughly two years old, and **no
+> newer Spur seed is available**. Astrill is the highest-weighted indicator in
+> `vpn_provider_scores.csv` (25 pre-hire / 30 post-hire), so the strongest
+> signal in the pipeline rests on the oldest data.
+>
+> Shodan org discovery partly compensates: see below.
+
+---
+
+## Shodan Org Discovery
+
+Four providers discover IPs beyond their seed lists via Shodan organisation
+search: **Astrill, Urban VPN, ExpressVPN, Hotspot Shield**.
+
+This path produced **nothing at all** until 2026-08-24. Every committed dataset
+had zero rows with a `shodan` source. Two causes, both silent:
+
+1. The search shelled out to the `shodan` CLI, which authenticates from
+   `~/.shodan/api_key` written by `shodan init` — it does **not** read the
+   environment. The workflow step running `vpn_ip_intel.py` set no
+   `SHODAN_API_KEY` at all, so no key existed in any form.
+2. Only `FileNotFoundError` and `TimeoutExpired` were caught. An
+   unauthenticated CLI exits non-zero with empty stdout, which the parser read
+   as "no results" — a dead credential was indistinguishable from a genuine
+   empty answer. The step is `continue-on-error`, so nothing surfaced.
+
+It now uses the Python API, which reads `SHODAN_API_KEY` from the environment,
+and pages with `search_cursor`. Failure modes are distinguishable: a missing key
+logs at ERROR naming the consequence, an empty result warns that the org name
+may be stale, and exceptions degrade to the seed rather than crashing.
+
+**The `Infrastructure Intel (ASN/VPN/Tor)` workflow step must pass
+`SHODAN_API_KEY`.** Without it these four providers fall back to seed lists
+only — which for Astrill means 2024 data.
+
+First results after the fix:
+
+| Provider | IPs discovered |
+|---|---|
+| ExpressVPN | 360 |
+| Hotspot Shield | 16 |
+| Astrill | 4 |
+
+Urban VPN returns **0**, which now emits a warning — the configured org string
+(`Urban VPN`) is likely wrong. Left visible rather than guessed at.
+
+### Checking it still works
+
+```bash
+# Should be non-zero. Zero means discovery has silently broken again.
+python -c "
+import csv, io, collections
+c = collections.Counter()
+for r in csv.DictReader(io.open('data/vpn_relay_ips.csv', encoding='utf-8', newline='')):
+    if 'shodan' in (r.get('source') or ''):
+        c[r['provider']] += 1
+print(sum(c.values()), dict(c))
+"
+```
 
 ---
 
@@ -105,6 +180,7 @@ gh run view $(gh run list --workflow=update_intelligence.yml --limit 1 --json da
 | Provider | Pre-hire Score | Post-hire Score | Tier | Evidence |
 |----------|---------------|----------------|------|----------|
 | Astrill | 25 | 30 | anchor | Mandiant, Microsoft, Spur, Unit42, SecurityScorecard |
+| Mullvad | 20 | 25 | anchor | Kudelski: 2nd most-used by DPRK IT workers, after Astrill |
 | ExpressVPN | 15 | 25 | anchor | Mandiant: RGB ORB tunnels |
 | NordVPN | 15 | 25 | anchor | Mandiant: UNC4899 JumpCloud |
 | TorGuard | 15 | 25 | anchor | Mandiant: UNC4899 JumpCloud |


### PR DESCRIPTION
None of the last two days' work was documented, and several existing README claims had drifted from the code.

## New — `docs/remote-access-detection.md`

Covers the IP-KVM / RMM capability end to end: why laptop farms use KVM hardware (no software on the host, so **EDR sees nothing**), the MITRE **T1219.003** / **DET0159** mapping and why DET0159's host-based analytics are unavailable to an external pipeline, the full signature tables, FP-0011's scoring rationale, and how to run both the classifier and the hunt.

**Records the measured facts that are easy to get wrong and fail *silently*:**

- Shodan supports neither boolean `OR` nor parentheses
- comma-separated values OR inside `http.title` but **not** inside `http.html` or `http.favicon.hash`, where a collapsed query returns **zero** results
- `http.html` consistently outperforms `http.title` — a site can rename its `<title>`, but the body keeps the words users read
- **`api.host()` does not bill query credits; searches do.** 145 lookups + 15 searches cost 99 credits, all from the searches

**Records what was rejected and why**, so nobody re-tries it:

| Candidate | Volume | Why not |
|---|---|---|
| `ssl.jarm:27d28d28d000…` | 10,439 | nginx TLS-stack fingerprint, not a device signature |
| `ssl.cert.issuer.CN:"PiKVM"` | 7 | Shodan doesn't index the cert organisation |
| favicon clustering for DEA | — | discriminates for IP-KVM, not for DEA |

**States the coverage caveat plainly:** Shodan surfaces ~600 PiKVM hosts where Silent Push observes 14,000+, so Shodan is supplementary here, not primary.

And carries the worked example of the AS29802 Guacamole host that passive DNS showed to be a **self-hosted homelab** — a hit in a large shared-hosting ASN is a lead, not an attribution.

## Corrected stale facts

- README said the pipeline runs at **11:00 UTC**; the cron is `0 7 * * *` → **07:00 UTC**
- README said **9** fingerprint rules and **37** test modules; there are **11** and **44**

## Updated

**README** — Remote Access Detection capability row; discovery and classification steps in the local-run walkthrough, with a note that `enrich_rmm_exposure` must precede `match_fingerprints` since FP-0011 matches the columns it writes; a Documentation section linking the three guides; current test figures plus the `tests.yml` gate and the `testpaths` setting.

**`vpn-ip-intel-operations.md`** — the Mullvad refresh (526 → 550 relays, plus the overwrite hazard that makes reconciling against the previous seed necessary); Mullvad added to the DPRK scoring table at 20/25; a flag that the Astrill seed is ~2 years old with **no newer Spur seed available**; and a new **Shodan Org Discovery** section explaining why that path silently produced nothing until 2026-08-24, with a snippet to check it still works.

## Verification

- [x] Every figure checked against the code, not asserted — fingerprint count from `ls config/fingerprints/*.yaml`, test count from an actual run, cron from the workflow file
- [x] Rebased onto current `main` so `hunt_kvm.py` references resolve
- [x] 846 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
