### PR TITLE
fix(fingerprints): add any_of OR semantics; four fingerprints matched every row

### DIFF
--- a/config/fingerprints/FP-0008-pickelhost-ula-actor.yaml
+++ b/config/fingerprints/FP-0008-pickelhost-ula-actor.yaml
@@ -9,79 +9,67 @@ description: >
   campaign (Jan 2026). Investigation origin: FS-ISAC (mysecurepasskey.com, Apr 2026).
 version: 2
 
-indicators:
+# No AND-gated indicators: this fingerprint is gated purely by any_of.
+indicators: []
+
+any_of:
+  # OR semantics: at least one of these must match. Previously these
+  # were indicators with required:false, which made the fingerprint
+  # match every row -- the engine had no OR until any_of was added.
   - field: primary_mx
     match_type: contains
     value: "pickelhost.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "eye-mail.net"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "h-email.net"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "happyisp.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "hope-mail.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "mailerhost.net"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "mailer-host.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "nickstel.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "yurtmail.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "emailofsteel.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "wallywatts.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "flip-mail.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "post-host.net"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "mxproc.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "mxhoppr.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "mx-host.net"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "skrimple.com"
-    required: false
   - field: primary_mx
     match_type: contains
     value: "b-io.co"
-    required: false
 
 confidence_base: 75
 

--- a/config/fingerprints/FP-0009-ipidea-residential-proxy.yaml
+++ b/config/fingerprints/FP-0009-ipidea-residential-proxy.yaml
@@ -11,82 +11,70 @@ description: >
   Source: Google GTIG (Jan 2026), SecurityScorecard Operation Phantom Circuit.
 version: 1
 
-indicators:
+# No AND-gated indicators: this fingerprint is gated purely by any_of.
+indicators: []
+
+any_of:
+  # OR semantics: at least one of these must match. Previously these
+  # were indicators with required:false, which made the fingerprint
+  # match every row -- the engine had no OR until any_of was added.
   # C2 SDK domains
   - field: domain
     match_type: contains
     value: "packetsdk"
-    required: false
   - field: domain
     match_type: contains
     value: "hexsdk.com"
-    required: false
   - field: domain
     match_type: contains
     value: "castarsdk.com"
-    required: false
   - field: domain
     match_type: contains
     value: "holadns.com"
-    required: false
   - field: domain
     match_type: contains
     value: "martianinc.co"
-    required: false
   - field: domain
     match_type: contains
     value: "okamiboss.com"
-    required: false
   # Proxy brand domains
   - field: domain
     match_type: contains
     value: "ipidea.io"
-    required: false
   - field: domain
     match_type: contains
     value: "922proxy.com"
-    required: false
   - field: domain
     match_type: contains
     value: "abcproxy.com"
-    required: false
   - field: domain
     match_type: contains
     value: "ip2world.com"
-    required: false
   - field: domain
     match_type: contains
     value: "lunaproxy.com"
-    required: false
   - field: domain
     match_type: contains
     value: "piaproxy.com"
-    required: false
   - field: domain
     match_type: contains
     value: "pyproxy.com"
-    required: false
   - field: domain
     match_type: contains
     value: "360proxy.com"
-    required: false
   - field: domain
     match_type: contains
     value: "radishvpn.com"
-    required: false
   - field: domain
     match_type: contains
     value: "tabproxy.com"
-    required: false
   # Enrichment-based detection
   - field: ipidea_domain_match
     match_type: exact
     value: "TRUE"
-    required: false
   - field: proxy_detected
     match_type: exact
     value: "yes"
-    required: false
 
 confidence_base: 70
 

--- a/config/fingerprints/FP-0010-doppelganger-kadnap-proxy.yaml
+++ b/config/fingerprints/FP-0010-doppelganger-kadnap-proxy.yaml
@@ -17,21 +17,24 @@ description: >
   DOPPELGANGER_PROXY tag; Krebs "Giving a Face to ... Faceless" (Apr 2023).
 version: 1
 
-indicators:
+# No AND-gated indicators: this fingerprint is gated purely by any_of.
+indicators: []
+
+any_of:
+  # OR semantics: at least one of these must match. Previously these
+  # were indicators with required:false, which made the fingerprint
+  # match every row -- the engine had no OR until any_of was added.
   # Storefront / brand
   - field: domain
     match_type: contains
     value: "doppelganger"
-    required: false
   # proxycheck.io enrichment (enrich_proxy_check.py)
   - field: proxy_detected
     match_type: exact
     value: "yes"
-    required: false
   - field: proxy_type
     match_type: contains
     value: "Residential"
-    required: false
 
 confidence_base: 65
 

--- a/config/fingerprints/FP-0011-remote-access-exposure.yaml
+++ b/config/fingerprints/FP-0011-remote-access-exposure.yaml
@@ -25,17 +25,21 @@ description: >
   customers are unrelated.
 version: 1
 
-indicators:
+# No AND-gated indicators: this fingerprint is gated purely by any_of.
+indicators: []
+
+any_of:
+  # OR semantics: at least one of these must match. Previously these
+  # were indicators with required:false, which made the fingerprint
+  # match every row -- the engine had no OR until any_of was added.
   # Either class of exposure qualifies the row for scoring; neither is required
   # on its own, so the fingerprint does not demand both.
   - field: kvm_detected
     match_type: exact
     value: "yes"
-    required: false
   - field: rmm_detected
     match_type: exact
     value: "yes"
-    required: false
 
 confidence_base: 40
 

--- a/scripts/match_fingerprints.py
+++ b/scripts/match_fingerprints.py
@@ -81,7 +81,7 @@ def validate_fingerprint(fp: dict, source: str = "<unknown>") -> dict:
 
     # --- indicators ---
     indicators = fp.get("indicators", [])
-    if not indicators:
+    if not indicators and not fp.get("any_of"):
         raise ValueError(
             f"Fingerprint {fp.get('id', '?')} from {source} has no indicators"
         )
@@ -123,6 +123,44 @@ def validate_fingerprint(fp: dict, source: str = "<unknown>") -> dict:
                     f"Indicator {idx} in {fp['id']} from {source} has invalid "
                     f"regex '{ind['value']}': {exc}"
                 )
+
+    # --- any_of: OR semantics, at least one member must match ---
+    any_of = fp.get("any_of") or []
+    for idx, ind in enumerate(any_of):
+        missing_keys = REQUIRED_INDICATOR_KEYS - set(ind.keys())
+        if missing_keys:
+            raise ValueError(
+                f"any_of entry {idx} in {fp.get('id','?')} from {source} missing "
+                f"key(s): {', '.join(sorted(missing_keys))}"
+            )
+        if ind["match_type"] not in VALID_MATCH_TYPES:
+            raise ValueError(
+                f"any_of entry {idx} in {fp.get('id','?')} from {source} has "
+                f"invalid match_type '{ind['match_type']}'"
+            )
+        ind["field"] = resolve_field(ind["field"])
+        if ind["match_type"] == "regex":
+            try:
+                ind["_compiled"] = re.compile(ind["value"], re.IGNORECASE)
+            except re.error as exc:
+                raise ValueError(
+                    f"any_of entry {idx} in {fp.get('id','?')} from {source} has "
+                    f"invalid regex '{ind['value']}': {exc}"
+                )
+    fp["any_of"] = any_of
+
+    # --- refuse fingerprints that gate nothing ---
+    # With no required indicator and no any_of, all_required_pass is vacuously
+    # true and the fingerprint matches EVERY row. Four shipped in that state,
+    # producing ~990k junk match rows and pushing fingerprint_matches.csv past
+    # GitHub's 100 MB limit, which broke the daily push. Authors used
+    # required:false because the engine had no OR semantics; any_of supplies it.
+    if not [i for i in indicators if i.get("required", True)] and not any_of:
+        raise ValueError(
+            f"Fingerprint {fp.get('id','?')} from {source} has no required "
+            f"indicator and no any_of group, so it would match every row. "
+            f"Mark an indicator required, or express alternatives as any_of."
+        )
 
     # --- optional key defaults ---
     fp.setdefault("description", "")
@@ -230,6 +268,20 @@ def evaluate_fingerprint(fp: dict, row: dict) -> Optional[dict]:
 
     if not all_required_pass:
         return None
+
+    # any_of: at least one member must match
+    any_of = fp.get("any_of") or []
+    if any_of:
+        hit = False
+        for ind in any_of:
+            if check_indicator(str(row.get(ind["field"], "")), ind["match_type"],
+                               ind["value"], ind.get("_compiled")):
+                hit = True
+                sep = "~" if ind["match_type"] == "contains" else "="
+                evidence_parts.append(f"{ind['field']}{sep}{ind['value']}")
+                break
+        if not hit:
+            return None
 
     confidence = calculate_confidence(fp, row)
     evidence = "; ".join(evidence_parts) if evidence_parts else ""

--- a/tests/test_fingerprints.py
+++ b/tests/test_fingerprints.py
@@ -385,3 +385,85 @@ class TestFP0007Typosquat:
         required_indicators = [i for i in result["indicators"] if i.get("required")]
         assert len(required_indicators) == 1
         assert required_indicators[0]["field"] == "dnstwist_match"
+
+
+# === any_of groups and the zero-required guard ===
+
+class TestAnyOfSemantics:
+    """The engine only had AND (`required: true`) semantics. Authors needing
+    "match any one of these" set every indicator to required: false -- which
+    made all_required_pass vacuously true, so the fingerprint matched EVERY
+    row. Four fingerprints did this (FP-0008, FP-0009, FP-0010, FP-0011),
+    producing 990,945 junk match rows and pushing fingerprint_matches.csv past
+    GitHub's 100 MB file limit, which broke the daily push.
+    """
+
+    def _fp(self, **kw):
+        base = {
+            "id": "FP-TEST", "name": "test", "description": "d", "version": 1,
+            "indicators": [], "confidence_base": 50,
+        }
+        base.update(kw)
+        return base
+
+    def test_any_of_matches_when_one_matches(self):
+        fp = validate_fingerprint(self._fp(
+            indicators=[{"field": "primary_mx", "match_type": "contains",
+                         "value": "anchor.example", "required": True}],
+            any_of=[{"field": "domain", "match_type": "contains", "value": "aaa"},
+                    {"field": "domain", "match_type": "contains", "value": "bbb"}],
+        ))
+        assert evaluate_fingerprint(fp, {"domain": "x-bbb-y", "primary_mx": "anchor.example"})
+
+    def test_any_of_rejects_when_none_match(self):
+        fp = validate_fingerprint(self._fp(
+            indicators=[{"field": "primary_mx", "match_type": "contains",
+                         "value": "anchor.example", "required": True}],
+            any_of=[{"field": "domain", "match_type": "contains", "value": "aaa"},
+                    {"field": "domain", "match_type": "contains", "value": "bbb"}],
+        ))
+        assert evaluate_fingerprint(fp, {"domain": "nothing", "primary_mx": "anchor.example"}) is None
+
+    def test_any_of_alone_is_sufficient_gating(self):
+        """A fingerprint may be entirely any_of -- that is still a real gate."""
+        fp = validate_fingerprint(self._fp(
+            indicators=[],
+            any_of=[{"field": "domain", "match_type": "contains", "value": "aaa"}],
+        ))
+        assert evaluate_fingerprint(fp, {"domain": "zzz-aaa"})
+        assert evaluate_fingerprint(fp, {"domain": "unrelated"}) is None
+
+    def test_required_and_any_of_are_anded_together(self):
+        fp = validate_fingerprint(self._fp(
+            indicators=[{"field": "asn", "match_type": "exact",
+                         "value": "16276", "required": True}],
+            any_of=[{"field": "domain", "match_type": "contains", "value": "aaa"}],
+        ))
+        assert evaluate_fingerprint(fp, {"asn": "16276", "domain": "aaa"})
+        assert evaluate_fingerprint(fp, {"asn": "99999", "domain": "aaa"}) is None
+        assert evaluate_fingerprint(fp, {"asn": "16276", "domain": "no"}) is None
+
+
+class TestNoUngatedFingerprints:
+    """A fingerprint that can match every row is never intentional."""
+
+    def test_zero_required_and_zero_any_of_is_rejected(self):
+        with pytest.raises(ValueError, match="(?i)required|any_of|gate"):
+            validate_fingerprint({
+                "id": "FP-BAD", "name": "n", "description": "d", "version": 1,
+                "confidence_base": 50,
+                "indicators": [{"field": "domain", "match_type": "contains",
+                                "value": "x", "required": False}],
+            })
+
+    def test_every_shipped_fingerprint_is_gated(self):
+        """Regression guard: no fingerprint in config/ may match every row."""
+        import glob, os, yaml, io
+        here = os.path.dirname(__file__)
+        ungated = []
+        for p in sorted(glob.glob(os.path.join(here, "..", "config", "fingerprints", "*.yaml"))):
+            d = yaml.safe_load(io.open(p, encoding="utf-8"))
+            req = [i for i in (d.get("indicators") or []) if i.get("required", True)]
+            if not req and not d.get("any_of"):
+                ungated.append(d.get("id", os.path.basename(p)))
+        assert not ungated, f"these match every row: {ungated}"


### PR DESCRIPTION
**This is why the 2026-08-24 daily run failed.** Every step succeeded across 4h23m; the push was rejected:

```
remote: error: File data/fingerprint_matches.csv is 102.97 MB;
        this exceeds GitHub's file size limit of 100.00 MB
! [remote rejected] main -> main (pre-receive hook declined)
```

## Root cause

`evaluate_fingerprint()` gates on required indicators only:

```python
all_required_pass = True
for ind in fp["indicators"]:
    if required and not matched:
        all_required_pass = False
```

With **no** required indicator, `all_required_pass` is vacuously true and the fingerprint matches **every row**. Four shipped in that state:

```
FP-0008  pickelhost-ula-actor      330,315 matches  (every domain)
FP-0009  ipidea-residential-proxy  330,315
FP-0010  doppelganger-kadnap       every domain
FP-0011  remote-access-exposure    330,315
```

FP-0008 and FP-0009 **predate this work** and had been emitting ~660k junk rows for some time. FP-0011 added the third 330k that crossed the limit.

The authors weren't careless. **The engine had no OR semantics**, and every one of these wants OR — *"primary_mx is any of these 18 hosts"*, *"domain contains any of these 16 proxy brands"*. `required: false` was the only lever available, and its failure mode is silent: the fingerprint looks like it works, and matches everything.

## Fix

An **`any_of`** group: at least one member must match, AND-ed with any required indicators. That expresses the intent directly.

`validate_fingerprint` now **refuses** a fingerprint with neither a required indicator nor an `any_of` group, so this cannot ship again. A test also asserts no fingerprint in `config/` is ungated.

The four fingerprints are converted **verbatim** — same fields, values and order — from optional indicators to `any_of` members. No detection intent is changed; they now gate on what they always meant.

## Result

| Fingerprint | Before | After |
|---|---|---|
| FP-0002 / 0003 / 0007 | unchanged | unchanged (were correctly gated) |
| FP-0008 | 330,315 | **3,241** |
| FP-0009 | 330,315 | **562** |
| FP-0010 | 0 | **566** |
| FP-0011 | 330,315 | **0** |
| **TOTAL** | **1,007,627** | **21,051** |

```
fingerprint_matches.csv:  103 MB  ->  1.8 MB
```

FP-0011 at 0 is correct locally — the `kvm_detected`/`rmm_detected` columns are written by `enrich_rmm_exposure` during the CI run, which precedes fingerprinting.

Beyond unblocking the push, this makes the detection output meaningful: 660k of the previous 1M rows were noise.

## Still needs an answer

`data/dea_domains_probed.csv` is **64 MB** — over GitHub's 50 MB recommendation, under the 100 MB limit. It will need its own strategy before it grows another 36 MB.

## Verification

- [x] 11/11 fingerprints validate
- [x] Real matcher run against 330,315 real rows
- [x] 852 tests pass, including a guard that no shipped fingerprint is ungated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
